### PR TITLE
GNU Parallel Semaphores Added

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -140,6 +140,7 @@ eout() {
 		fi
     fi
 }
+export -f eout
 
 trap_exit() {
 	if [ "$svc" == "m" ]; then
@@ -287,9 +288,11 @@ usage $0 [ OPTION ]
        Scan files created/modified in the last X days (default: 7d, wildcard: ?)
        e.g: maldet -r /home/?/public_html 2
 
-    -a, --scan-all PATH
+    -a, --scan-all PATH MAX-PROCS
        Scan all files in path (default: /home, wildcard: ?)
        e.g: maldet -a /home/?/public_html
+       e.g: maldet -a /home/?/public_html 15
+            (will parallelize the scanning to 15 threads) 
 
     -i, --include-regex REGEX
        Include paths/files from file list based on supplied posix-egrep regular
@@ -668,6 +671,7 @@ scan() {
  scan_start=`date +"%s"`
  spath=`echo $1 | tr '?' '*' | tr ',' ' '`
  days="$2"
+ maxcpu="$3"
  scanid="$datestamp.$$"
  if [ "$file_list" ]; then
 	spath="$file_list"
@@ -958,10 +962,17 @@ scan() {
 	echo -en "\\033[${res_col}G" && echo -n "maldet($$): {scan} $cnt/$tot_files files scanned: $tot_hit hits $cl_hit cleaned"
    fi
    if [ -f "$rpath" ]; then
-   	scan_stage1 "$rpath" >> /dev/null 2>&1
+    export md5sum=$md5sum
+    export sig_cust_md5_file=$sig_cust_md5_file
+    export sig_md5_file=$sig_md5_file
+    sem -j $maxcpu scan_stage1 "$rpath"
+#     parallel --max-procs $maxcpu scan_stage1 ::: $rpath
+#   	scan_stage1 "$rpath" >> /dev/null 2>&1
+#        echo $rpath
    fi
 
   done
+  sem --wait
   IFS=$SAVEIFS
  fi
 
@@ -1059,6 +1070,7 @@ scan_stage1() {
 	eout "{scan} error could not read or hash $file, do we have permission?"
  fi
 }
+export -f scan_stage1
 
 scan_stage2() {
  file="$1"

--- a/files/maldet
+++ b/files/maldet
@@ -191,14 +191,18 @@ else
 		svc=a
 		trap trap_exit 2
 		spath="$1"
+		maxprocs="$2"
 		if [ "$spath" == "" ]; then
 			spath=/home
 		fi
+		if  [ "$maxprocs" == "" ] ; then
+			maxprocs=1;		
+		fi
 		if [ "$set_background" == "1" ]; then
 			eout "{scan} launching scan of $spath to background, see $maldet_log for progress" 1
-                        scan "$spath" all >> /dev/null 2>&1 &
+                        scan "$spath" all $maxprocs >> /dev/null 2>&1 &
 		else
-		        scan "$spath" all
+		        scan "$spath" all $maxprocs
 		fi
 	;;
 	-r|--scan-recent)


### PR DESCRIPTION
First go ahead with semaphores for LMD. Using GNU's parallel program (perl
threads with file locking) we are able to parallelize the file scanning
process which is the bottleneck in this process.

Users can pass in the number of threads at run by the -a param:
    maldet -a /home/?/public_html 15
This will run 15 thread scans.....^^

With one test case pass, I suspect more bugs exists in this implementation. So
far that one test cases includes scanning the /tmp directory where no hits
were found. In addition, the test case was not branch coverage so some if /
logic statements were never ran.

The downfall of using semaphores within bash is variable scope -- they need to
be exported into the environment. This is where most bugs will be introduced.

Signed-off-by: Adam Brenner aebrenne@uci.edu
