### PR TITLE
fix interpreter for uninstall.sh

### DIFF
--- a/files/uninstall.sh
+++ b/files/uninstall.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 echo "This will completely remove Linux Malware Detect from your server including all quarantine data!"
 echo -n "Would you like to proceeed? "
-read -p "[y/n] " -n1 Z
+read -p "[y/n] " -n 1 Z
 echo
 if [ "$Z" == "y" ] || [ "$Z" == "Y" ]; then
 	rm -rf /usr/local/maldetect* /etc/cron.d/maldet_pub /etc/cron.daily/maldet /usr/local/sbin/maldet /usr/local/sbin/lmd


### PR DESCRIPTION
Hello all.
Im run uninstall.sh on:
Ubuntu 13.04 and Debian GNU/Linux 7.6 but get error:
# ./files/uninstall.sh

This will completely remove Linux Malware Detect from your server including all quarantine data!
Would you like to proceeed? ./files/uninstall.sh: 4: read: Illegal option -n

./files/uninstall.sh: 6: [: unexpected operator
./files/uninstall.sh: 6: [: unexpected operator
You selected No or provided an invalid confirmation, nothing has been done!

Becasue on this system's sh linked to dash:
$ whereis sh
sh: /bin/sh.distrib /bin/sh /usr/share/man/man1/sh.1.gz
$ ls /bin/sh
lrwxrwxrwx 1 root root 4 Авг 13  2013 /bin/sh -> dash
$ ls -lh /bin/dash 
-rwxr-xr-x 1 root root 108K Авг 15  2012 /bin/dash

So I change /bin/sh to /bin/bash
What do u think?
