### PR TITLE
Fixing error /usr/bin/wc: /usr/local/maldetect/sess/inotify.paths.18129:...

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1335,7 +1335,7 @@ if [ "$(echo $inopt | grep -E "users|user|USERS|USER")" ]; then
 	eout "{mon} added /tmp to inotify monitoring array" 1
  fi
 elif [ -f "$inopt" ]; then
-	tot_paths=`$wc -l $inotify_fpaths | awk '{print$1}'`
+	tot_paths=`$wc -l $inopt | awk '{print$1}'`
 	if [ "$tot_paths" == "0" ]; then
 		eout "{mon} no paths specified in $inopt, aborting." 1
 		exit


### PR DESCRIPTION
Fixing error
`Fixing error /usr/bin/wc: /usr/local/maldetect/sess/inotify.paths.$$: No such file or directory`
when using monitor with paths from file.
