### PR TITLE
fix report on user suspension from inotify monitor

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -594,6 +594,7 @@ record_hit() {
 quarantine() {
 file="$1"
 hitname="$2"
+file_name=`basename "$file"`
 user=`$stat -c "%U" "$file"`
 if [ -f "$file" ] && [ -d "$quardir" ]; then
  if [ "$quarantine_hits" == "1" ]; then

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1212,6 +1212,7 @@ monitor_kill() {
 monitor_cycle() {
  status=$1
  echo $$ > $tmpdir/monitor.pid
+ inotify_cycle_runtime=0
  if [ ! -f "$tmpdir/stop_monitor" ]; then
 	 inotify_pid=`$pidof inotifywait`
 	 if [ -z "$inotify_pid" ]; then
@@ -1224,7 +1225,7 @@ monitor_cycle() {
                 printf "%s\n" "$trim,${log_size}d" w | ed -s $inotify_log
                 eout "{mon} inotify log file trimmed"
          fi
-	 if [ "$inotify_cycle_runtime" -ge "$inotify_reloadtime" ]; then
+	 if [ $inotify_cycle_runtime -ge $inotify_reloadtime ]; then
 	 	source $cnf
 	 	source $intcnf
 	 	import_conf
@@ -1233,10 +1234,10 @@ monitor_cycle() {
 	 fi
 	 sleep $inotify_sleep
 	 inotify_cycle_runtime=$[inotify_sleep+inotify_cycle_runtime]
-	 if [ $status -eq 1 ]; then
-	 	monitor_check 1
+	 if [ "$status" == "1" ]; then
+	 	monitor_check "1"
 	 else
-	 	monitor_check 0
+	 	monitor_check "0"
 	 fi
  else
 	rm -f $tmpdir/stop_monitor
@@ -1250,9 +1251,10 @@ gensigs_status=$1
 for file in `$tlog $inotify_log inotify | grep -E "CREATE|MODIFY|MOVED_FROM|MOVED_TO" | awk '{print$1}' | sort | uniq | tr ' ' '%'`; do
  file=`echo $file | tr '%' ' '`
  if [ -f "$file" ]; then
-  if [ $gensigs_status -eq 0 ]; then
+  if [ "$gensigs_status" == "0" ]; then
 	  sigignore 1
 	  gensigs
+	  gensigs_status=1
   fi
   echo "$file" >> $sessdir/.monitor.scanned.alltime
   eout "{mon} inotify file scan $file"

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -559,7 +559,8 @@ user_id=`id -u $user`
 if [ ! "$user" == "" ] && [ "$user_id" -ge "$quarantine_suspend_user_minuid" ]; then
 	if [ -f "/scripts/suspendacct" ]; then
 		if [ ! -f "/var/cpanel/suspended/$user" ]; then
-		 /scripts/suspendacct $user "maldet --report $datestamp.$$ --user $user" >> /dev/null 2>&1
+		 current_scan_id=`echo $scan_session | awk -F "." '{ print $3 "." $4 }'`
+		 /scripts/suspendacct $user "maldet --report $current_scan_id --user $user" >> /dev/null 2>&1
 		 eout "{quar} account $user cpanel suspended" 1
 		 echo "$user" >> $sessdir/suspend.users.$$
                  echo "$user" >> $sessdir/.susp.alltime

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1209,6 +1209,7 @@ monitor_kill() {
 }
 
 monitor_cycle() {
+ status=$1
  echo $$ > $tmpdir/monitor.pid
  if [ ! -f "$tmpdir/stop_monitor" ]; then
 	 inotify_pid=`$pidof inotifywait`
@@ -1231,7 +1232,11 @@ monitor_cycle() {
 	 fi
 	 sleep $inotify_sleep
 	 inotify_cycle_runtime=$[inotify_sleep+inotify_cycle_runtime]
-	 monitor_check
+	 if [ $status -eq 1 ]; then
+	 	monitor_check 1
+	 else
+	 	monitor_check 0
+	 fi
  else
 	rm -f $tmpdir/stop_monitor
 	eout "{mon} monitoring terminated by user, inotify killed."
@@ -1240,17 +1245,20 @@ monitor_cycle() {
 }
 
 monitor_check() {
+gensigs_status=$1
 for file in `$tlog $inotify_log inotify | grep -E "CREATE|MODIFY|MOVED_FROM|MOVED_TO" | awk '{print$1}' | sort | uniq | tr ' ' '%'`; do
  file=`echo $file | tr '%' ' '`
  if [ -f "$file" ]; then
-  sigignore 1
-  gensigs
+  if [ $gensigs_status -eq 0 ]; then
+	  sigignore 1
+	  gensigs
+  fi
   echo "$file" >> $sessdir/.monitor.scanned.alltime
   eout "{mon} inotify file scan $file"
   scan_stage1 "$file" >> /dev/null 2>&1
  fi
 done
-monitor_cycle
+monitor_cycle 1
 }
 
 monitor_init() {

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -421,7 +421,7 @@ clean() {
 		exit
 	else
 		eout "Quarantine or Clean is currently disabled, cleaning is not possible!" $v
-		exit		
+		exit
 	fi
  fi
 }
@@ -520,6 +520,10 @@ view_report() {
         rm -f $tmpf
         exit
  fi
+ if [ -f "$sessdir/session.hits.$rid" ] && [ ! -z "$2" ] && [ ! -z "$3" ] && [ "$2" == "--user" ]; then
+	cat "$sessdir/session.hits.$rid" | grep "^$3 :" |less
+	exit
+ fi
  if [ -f "$sessdir/session.$rid" ] && [ ! -z "$(echo $2 | grep '\@')" ]; then
 	cat $sessdir/session.$rid | mail -s "$email_subj" $2
 	eout "{report} report ID $rid sent to $2" 1
@@ -555,7 +559,7 @@ user_id=`id -u $user`
 if [ ! "$user" == "" ] && [ "$user_id" -ge "$quarantine_suspend_user_minuid" ]; then
 	if [ -f "/scripts/suspendacct" ]; then
 		if [ ! -f "/var/cpanel/suspended/$user" ]; then
-		 /scripts/suspendacct $user "maldet --report $datestamp.$$" >> /dev/null 2>&1
+		 /scripts/suspendacct $user "maldet --report $datestamp.$$ --user $user" >> /dev/null 2>&1
 		 eout "{quar} account $user cpanel suspended" 1
 		 echo "$user" >> $sessdir/suspend.users.$$
                  echo "$user" >> $sessdir/.susp.alltime
@@ -590,6 +594,7 @@ record_hit() {
 quarantine() {
 file="$1"
 hitname="$2"
+user=`$stat -c "%U" "$file"`
 if [ -f "$file" ] && [ -d "$quardir" ]; then
  if [ "$quarantine_hits" == "1" ]; then
 	file_namewc=`echo $file_name | $wc -m`
@@ -609,7 +614,7 @@ if [ -f "$file" ] && [ -d "$quardir" ]; then
 	eout "{quar} malware quarantined from '$file' to '$quardir/$file_name.$rnd'"
 	echo "$file => $quardir/$file_name.$rnd" >> $sessdir/.quar.alltime
 	if [ ! -z "$scan_session" ]; then
-		echo "$hitname : $file => $quardir/$file_name.$rnd" >> $scan_session
+		echo "$user : $hitname : $file => $quardir/$file_name.$rnd" >> $scan_session
 	fi
 	if [ "$quarantine_clean" == "1" ] && [ ! "$cleanst" == "1" ]; then
 		unset cleanst
@@ -1068,7 +1073,10 @@ scan_stage1() {
 scan_stage2() {
  file="$1"
  clchk="$2"
- if [ -z "$ftype" ]; then
+ ## I do believe here needed to be checking the $file variable? What's $ftype??
+ ## Anyway, this will always be 0 so no point checking...
+ ## if [ -z "$ftype" ]; then
+ if [ ! -z "$file" ]; then
 	if [ -p "$hex_fifo_path" ] && [ "$scan_hexfifo" == "1" ]; then
                 if [ "$OSTYPE" == "FreeBSD" ]; then
                         $od -v -N$scan_hexfifo_depth -tx1 "$file" | cut -c12-256 | tr -d ' \n' > $hex_fifo_path 2>&1 &

--- a/files/maldet
+++ b/files/maldet
@@ -152,7 +152,7 @@ else
 			monitor_init "$1"
 		fi
 	;;
-	-k|--kill-monitor)
+	-k|--kill-monitor|-kill)
 		header
 		if [ "$OSTYPE" == "FreeBSD" ]; then
 			eout "{mon} not currently supported under FreeBSD" 1

--- a/files/maldet
+++ b/files/maldet
@@ -152,7 +152,7 @@ else
 			monitor_init "$1"
 		fi
 	;;
-	-k|--kill-monitor|-kill)
+	-k|--kill-monitor)
 		header
 		if [ "$OSTYPE" == "FreeBSD" ]; then
 			eout "{mon} not currently supported under FreeBSD" 1
@@ -230,7 +230,11 @@ else
 	-e|--report)
 		header
 		shift
-		view_report "$1" "$2"
+		if [ ! -z "$2" ] && [ "$2" == "--user" ] && [ ! -z "$3" ]; then
+			view_report "$1" "$2" "$3"
+		else
+			view_report "$1" "$2"
+		fi
 	;;
 	-p|--purge)
 		header


### PR DESCRIPTION
Hello Ryan,

Upon cpanel user being suspended, the report there would fail to work anymore.
Added ability to find what files triggered a suspension for that specific user
example usage:
``` maldet --report SCANID --user CPANEL_USER ```

Please review code before merging and let me know what you think. If possible to find / show report in a better way, please let me know.