### PR TITLE
This adds system startup scripts for maldet monitoring.

### DIFF
--- a/files/service/maldet.service
+++ b/files/service/maldet.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Linux Malware Detect monitoring - maldet
+After=network.target
+
+[Service]
+ExecStart=/usr/local/maldetect/maldet --monitor /usr/local/maldetect/monitor_paths
+ExecStop=/usr/local/maldetect/maldet --kill-monitor
+Type=forking
+PIDFile=/usr/local/maldetect/tmp/inotifywait.pid
+[Install]
+WantedBy=multi-user.target

--- a/files/service/maldet.sh
+++ b/files/service/maldet.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# maldet    Linux Malware Detect monitoring
+#
+# chkconfig: 345 70 30
+# description: Linux Malware Detect file monitoring
+# processname: maldet
+
+# Source function library.
+. /etc/init.d/functions
+
+RETVAL=0
+prog="maldet"
+LOCKFILE=/var/lock/subsys/$prog
+
+start() {
+        echo -n "Starting $prog: "
+        /usr/local/maldetect/maldet --monitor /usr/local/maldetect/monitor_paths
+        RETVAL=$? [ $RETVAL -eq 0 ] && touch $LOCKFILE
+        echo
+        return $RETVAL
+}
+
+stop() {
+        echo -n "Shutting down $prog: "
+        /usr/local/maldetect/maldet --kill-monitor && success || failure
+        RETVAL=$? [ $RETVAL -eq 0 ] && rm -f $LOCKFILE
+        echo
+        return $RETVAL
+}
+
+restart() {
+        stop
+        start
+}
+
+status() {
+        echo -n "Checking $prog monitoring status: "
+        if [ "$(ps -A --user root -o "cmd" | grep maldetect | grep inotifywait)" ]; then
+            echo "Running"
+        else
+            echo "Not running"
+        fi
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status
+        ;;
+    restart)
+        restart
+        ;;
+    condrestart)
+        if [ -f $LOCKFILE ]; then
+            restart
+        fi
+        ;;
+    *)
+        echo "Usage: $prog {start|stop|status|restart|condrestart}"
+        exit 1
+        ;;
+esac
+exit $RETVAL

--- a/files/uninstall.sh
+++ b/files/uninstall.sh
@@ -5,6 +5,32 @@ read -p "[y/n] " -n 1 Z
 echo
 if [ "$Z" == "y" ] || [ "$Z" == "Y" ]; then
 	rm -rf /usr/local/maldetect* /etc/cron.d/maldet_pub /etc/cron.daily/maldet /usr/local/sbin/maldet /usr/local/sbin/lmd
+
+	if test `cat /proc/1/comm` = "systemd"
+    then
+        systemctl disable maldet.service
+        systemctl stop maldet.service
+        rm -f /usr/lib/systemd/system/maldet.service
+        systemctl daemon-reload
+    else
+        if [ -f /etc/redhat-release ]; then
+            /sbin/chkconfig maldet off
+            /sbin/chkconfig maldet --del
+        elif [ -f /etc/debian_version ] || [ -f /etc/lsb-release ]; then
+            update-rc.d -f maldet remove
+        elif [ -f /etc/gentoo-release ]; then
+            rc-update del maldet default
+        elif [ -f /etc/slackware-version ]; then
+            rm -f /etc/rc.d/rc3.d/S70maldet
+            rm -f /etc/rc.d/rc4.d/S70maldet
+            rm -f /etc/rc.d/rc5.d/S70maldet
+        else
+            /sbin/chkconfig maldet off
+            /sbin/chkconfig maldet --del
+        fi
+    rm -f /etc/init.d/maldet
+fi
+
 	echo "Linux Malware Detect has been uninstalled."
 else
 	echo "You selected No or provided an invalid confirmation, nothing has been done!"

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,33 @@ if [ -d "/etc/cron.d" ]; then
 	chmod 644 /etc/cron.d/maldet_pub
 fi
 
+if test `cat /proc/1/comm` = "systemd"
+then
+    mkdir -p /etc/systemd/system/
+    mkdir -p /usr/lib/systemd/system/
+    cp -af ./files/service/maldet.service /usr/lib/systemd/system/
+    systemctl daemon-reload
+    systemctl enable maldet.service
+else
+    cp -af ./files/service/maldet.sh /etc/init.d/maldet
+    chmod 755 /etc/init.d/maldet
+
+    if [ -f /etc/redhat-release ]; then
+        /sbin/chkconfig maldet on
+    elif [ -f /etc/debian_version ] || [ -f /etc/lsb-release ]; then
+        update-rc.d -f maldet remove
+        update-rc.d maldet defaults 70 30
+    elif [ -f /etc/gentoo-release ]; then
+        rc-update add maldet default
+    elif [ -f /etc/slackware-version ]; then
+        ln -sf /etc/init.d/maldet /etc/rc.d/rc3.d/S70maldet
+        ln -sf /etc/init.d/maldet /etc/rc.d/rc4.d/S70maldet
+        ln -sf /etc/init.d/maldet /etc/rc.d/rc5.d/S70maldet
+    else
+        /sbin/chkconfig maldet on
+    fi
+fi
+
 	mkdir -p $inspath/logs && touch $logf
 	ln -fs $logf $inspath/event_log
 	$inspath/maldet --alert-daily


### PR DESCRIPTION
The install and uninstall scripts now properly detect if you are running systemd or sysvinit.
Note: The startup scripts expect that you have paths defined in /usr/local/maldetect/monitor_paths