### PR TITLE
Makes sure that maldet startup scripts are not installed for FreeBSD

### DIFF
--- a/files/uninstall.sh
+++ b/files/uninstall.sh
@@ -4,32 +4,33 @@ echo -n "Would you like to proceeed? "
 read -p "[y/n] " -n 1 Z
 echo
 if [ "$Z" == "y" ] || [ "$Z" == "Y" ]; then
-	rm -rf /usr/local/maldetect* /etc/cron.d/maldet_pub /etc/cron.daily/maldet /usr/local/sbin/maldet /usr/local/sbin/lmd
-
-	if test `cat /proc/1/comm` = "systemd"
-    then
-        systemctl disable maldet.service
-        systemctl stop maldet.service
-        rm -f /usr/lib/systemd/system/maldet.service
-        systemctl daemon-reload
-    else
-        if [ -f /etc/redhat-release ]; then
-            /sbin/chkconfig maldet off
-            /sbin/chkconfig maldet --del
-        elif [ -f /etc/debian_version ] || [ -f /etc/lsb-release ]; then
-            update-rc.d -f maldet remove
-        elif [ -f /etc/gentoo-release ]; then
-            rc-update del maldet default
-        elif [ -f /etc/slackware-version ]; then
-            rm -f /etc/rc.d/rc3.d/S70maldet
-            rm -f /etc/rc.d/rc4.d/S70maldet
-            rm -f /etc/rc.d/rc5.d/S70maldet
+    if [ "$OSTYPE" != "FreeBSD" ]; then
+        if test `cat /proc/1/comm` = "systemd"
+        then
+            systemctl disable maldet.service
+            systemctl stop maldet.service
+            rm -f /usr/lib/systemd/system/maldet.service
+            systemctl daemon-reload
         else
-            /sbin/chkconfig maldet off
-            /sbin/chkconfig maldet --del
+            if [ -f /etc/redhat-release ]; then
+                /sbin/chkconfig maldet off
+                /sbin/chkconfig maldet --del
+                elif [ -f /etc/debian_version ] || [ -f /etc/lsb-release ]; then
+                update-rc.d -f maldet remove
+                elif [ -f /etc/gentoo-release ]; then
+                rc-update del maldet default
+                elif [ -f /etc/slackware-version ]; then
+                rm -f /etc/rc.d/rc3.d/S70maldet
+                rm -f /etc/rc.d/rc4.d/S70maldet
+                rm -f /etc/rc.d/rc5.d/S70maldet
+            else
+                /sbin/chkconfig maldet off
+                /sbin/chkconfig maldet --del
+            fi
+            rm -f /etc/init.d/maldet
         fi
-    rm -f /etc/init.d/maldet
-fi
+    fi
+	rm -rf /usr/local/maldetect* /etc/cron.d/maldet_pub /etc/cron.daily/maldet /usr/local/sbin/maldet /usr/local/sbin/lmd
 
 	echo "Linux Malware Detect has been uninstalled."
 else

--- a/install.sh
+++ b/install.sh
@@ -81,30 +81,31 @@ if [ -d "/etc/cron.d" ]; then
 	chmod 644 /etc/cron.d/maldet_pub
 fi
 
-if test `cat /proc/1/comm` = "systemd"
-then
-    mkdir -p /etc/systemd/system/
-    mkdir -p /usr/lib/systemd/system/
-    cp -af ./files/service/maldet.service /usr/lib/systemd/system/
-    systemctl daemon-reload
-    systemctl enable maldet.service
-else
-    cp -af ./files/service/maldet.sh /etc/init.d/maldet
-    chmod 755 /etc/init.d/maldet
-
-    if [ -f /etc/redhat-release ]; then
-        /sbin/chkconfig maldet on
-    elif [ -f /etc/debian_version ] || [ -f /etc/lsb-release ]; then
-        update-rc.d -f maldet remove
-        update-rc.d maldet defaults 70 30
-    elif [ -f /etc/gentoo-release ]; then
-        rc-update add maldet default
-    elif [ -f /etc/slackware-version ]; then
-        ln -sf /etc/init.d/maldet /etc/rc.d/rc3.d/S70maldet
-        ln -sf /etc/init.d/maldet /etc/rc.d/rc4.d/S70maldet
-        ln -sf /etc/init.d/maldet /etc/rc.d/rc5.d/S70maldet
+if [ "$OSTYPE" != "FreeBSD" ]; then
+    if test `cat /proc/1/comm` = "systemd"
+    then
+        mkdir -p /etc/systemd/system/
+        mkdir -p /usr/lib/systemd/system/
+        cp -af ./files/service/maldet.service /usr/lib/systemd/system/
+        systemctl daemon-reload
+        systemctl enable maldet.service
     else
-        /sbin/chkconfig maldet on
+        cp -af ./files/service/maldet.sh /etc/init.d/maldet
+        chmod 755 /etc/init.d/maldet
+        if [ -f /etc/redhat-release ]; then
+            /sbin/chkconfig maldet on
+            elif [ -f /etc/debian_version ] || [ -f /etc/lsb-release ]; then
+            update-rc.d -f maldet remove
+            update-rc.d maldet defaults 70 30
+            elif [ -f /etc/gentoo-release ]; then
+            rc-update add maldet default
+            elif [ -f /etc/slackware-version ]; then
+            ln -sf /etc/init.d/maldet /etc/rc.d/rc3.d/S70maldet
+            ln -sf /etc/init.d/maldet /etc/rc.d/rc4.d/S70maldet
+            ln -sf /etc/init.d/maldet /etc/rc.d/rc5.d/S70maldet
+        else
+            /sbin/chkconfig maldet on
+        fi
     fi
 fi
 


### PR DESCRIPTION
Makes sure that maldet startup scripts are not installed for FreeBSD as it doesn't support inotify file monitoring. Also fixed the uninstaller to turn off monitoring before maldet is removed.