### PR TITLE
Removing absolut path of 'pidof'

### DIFF
--- a/files/hookscan.sh
+++ b/files/hookscan.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 file="$1"
-isclamd=`/sbin/pidof clamd 2> /dev/null`
+isclamd=`pidof clamd 2> /dev/null`
 clamdloc=`which clamdscan 2> /dev/null`
 if [ "$isclamd" ] && [ -f "$clamdloc" ]; then
 	clamd_scan=1


### PR DESCRIPTION
Maybe it's better to use 'which' to find the path of the binary. But I think this is not needed in this case.