### PR TITLE
Introducing $userbasedir to be able to move this directory elsewhere

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -22,10 +22,10 @@ prerun() {
 		fi
 		pub=1
 		user=`whoami`
-		quardir="$inspath/pub/$user/quar"
-		sessdir="$inspath/pub/$user/sess"
-		tmpdir="$inspath/pub/$user/tmp"
-		maldet_log="$inspath/pub/$user/event_log"
+		quardir="$userbasedir/$user/quar"
+		sessdir="$userbasedir/$user/sess"
+		tmpdir="$userbasedir/$user/tmp"
+		maldet_log="$userbasedir/$user/event_log"
 		mkdir -p $quardir >> /dev/null 2>&1
 		mkdir -p $sessdir >> /dev/null 2>&1
 		mkdir -p $tmpdir >> /dev/null 2>&1

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -53,6 +53,7 @@ sessdir="$inspath/sess"
 sigdir="$inspath/sigs"
 cldir="$inspath/clean"
 tmpdir="$inspath/tmp"
+userbasedir="$inspath/pub"
 
 sig_version_file="$sigdir/maldet.sigs.ver"
 if [ -f "$sig_version_file" ]; then

--- a/files/maldet
+++ b/files/maldet
@@ -61,7 +61,7 @@ else
 		case "$1" in
 			--mkpubpaths)
 				if [ "$scan_user_access" == "1" ]; then
-					chmod 711 $inspath/pub
+					chmod 711 $userbasedir
 					for user in `cat /etc/passwd | cut -d ':' -f1`; do
 						uid=`id --user $user`
 						if [ -z "$uid" ]; then
@@ -70,12 +70,12 @@ else
 						if [ -z "$scan_user_access_minuid" ]; then
 							scan_user_access_minuid=10
 						fi
-						if [ "$uid" -ge "$scan_user_access_minuid" ] && [ ! -d "$inspath/pub/$user" ]; then
-							mkdir -p $inspath/pub/$user/quar $inspath/pub/$user/sess $inspath/pub/$user/tmp >> /dev/null 2>&1
-							touch $inspath/pub/$user/event_log >> /dev/null 2>&1
-							chown -R $user.$user $inspath/pub/$user >> /dev/null 2>&1
-							chmod 750 $inspath/pub/$user $inspath/pub/$user/quar $inspath/pub/$user/sess $inspath/pub/$user/tmp >> /dev/null 2>&1
-							chmod 640 $inspath/pub/$user/event_log >> /dev/null 2>&1
+						if [ "$uid" -ge "$scan_user_access_minuid" ] && [ ! -d "$userbasedir/$user" ]; then
+							mkdir -p $userbasedir/$user/quar $inspath/pub/$user/sess $inspath/pub/$user/tmp >> /dev/null 2>&1
+							touch $userbasedir/$user/event_log >> /dev/null 2>&1
+							chown -R $user.$user $userbasedir/$user >> /dev/null 2>&1
+							chmod 750 $userbasedir/$user $inspath/pub/$user/quar $inspath/pub/$user/sess $inspath/pub/$user/tmp >> /dev/null 2>&1
+							chmod 640 $userbasedir/$user/event_log >> /dev/null 2>&1
 							eout "{glob} created public scanning paths for user $user"
 						fi
 						unset uid user
@@ -93,16 +93,16 @@ else
 			-U|--user)
 				shift
 				user="$1"
-				quardir=$inspath/pub/$user/quar
-				sessdir=$inspath/pub/$user/sess
-				tmpdir=$inspath/pub/$user/tmp
-				maldet_log=$inspath/pub/$user/event_log
+				quardir=$userbasedir/$user/quar
+				sessdir=$userbasedir/$user/sess
+				tmpdir=$userbasedir/$user/tmp
+				maldet_log=$userbasedir/$user/event_log
 			;;
 			-co|--config-option)
 				shift
 				user=`whoami`
 				if [ ! "$user" == "root" ]; then
-					tmpdir=$inspath/pub/$user/tmp
+					tmpdir=$userbasedir/$user/tmp
 				fi
 				tmpco=$tmpdir/config.cli
 				rm -f $tmpco


### PR DESCRIPTION
The FHS says the variable data has to be in /var, the binaries (and scripts)
needs to be in /usr. So the user dirs have to go seperated from the programs.