### PR TITLE
Droping unneeded shebang

### DIFF
--- a/files/conf.maldet
+++ b/files/conf.maldet
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 ##
 # Linux Malware Detect v1.5
 #             (C) 2002-2015, R-fx Networks <proj@r-fx.org>

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 ##
 # Linux Malware Detect v1.5
 #             (C) 2002-2015, R-fx Networks <proj@r-fx.org>

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 ##
 # Linux Malware Detect v1.5
 #             (C) 2002-2015, R-fx Networks <proj@r-fx.org>

--- a/files/internals/scan.etpl
+++ b/files/internals/scan.etpl
@@ -1,4 +1,3 @@
-#!/bin/bash
 if [ -z "$type" ]; then
 	type=scan
 fi


### PR DESCRIPTION
The shebang in this files is not needed, as those files are included into
other files. In this case the shebang is not needed.

I droped the shebang in my Debian package via https://github.com/waja/maldetect/blob/master/debian/patches/0006-20_maldetect-remove-shebang.patch. Lintian is complaining about the unneeded shebang.