### PR TITLE
fix for #73

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -735,9 +735,9 @@ scan() {
 		fi
 		if [ -f "/usr/local/cpanel/3rdparty/bin/$clambin" ]; then
 			clamscan="/usr/local/cpanel/3rdparty/bin/$clambin"
-			elif [ -f "$(which clamdscan 2> /dev/null)" ]; then
+		elif [ "$isclamd" ] && [ "$isclamd_root" ] && [ -f "$(which clamdscan 2> /dev/null)" ]; then
 			clamscan=`which clamdscan 2> /dev/null`
-			elif [ -f "$(which clamscan 2> /dev/null)" ]; then
+		elif [ -f "$(which clamscan 2> /dev/null)" ]; then
 			clamscan=`which clamscan 2> /dev/null`
 		else
 			scan_clamscan="0"


### PR DESCRIPTION
This is a fix for #73, so clamdscan will only be used, if it runs and runs as root.