### PR TITLE
Incorrect command causes a command not found

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1151,7 +1151,7 @@ trim_log() {
 		log_size=`$wc -l $log | awk '{print$1}'`
 		if [ "$log_size" -gt "$logtrim" 2> /dev/null ]; then
 			trim=$[logtrim/10]
-			printf "%s\n" "$trim,${log_size}d" w | ed -s $log
+			printf "%s\n" "$trim,${log_size}d" w | sed -s $log
 		fi
 		elif [ ! -f "$log" ] && [ "$3" == "1" ]; then
 		touch $log ; chmod 640 $log


### PR DESCRIPTION
The line 1154 had ed instead of sed, which caused an incorrect comand.