### PR TITLE
Fix zombie child rfxn/linux-malware-detect#101

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1229,7 +1229,8 @@ monitor_kill() {
 	else
 		exit_code="1"
 	fi
-	kill -9 $inotify_pid $monitor_pid >> /dev/null 2>&1
+	monitor_pgid=`ps -p "$monitor_pid" -o pgid= | tr -d ' '`
+	kill -9 -- $inotify_pid -$monitor_pgid >> /dev/null 2>&1
 	killall -9 inotifywait >> /dev/null 2>&1
 	exit $exit_code
 }


### PR DESCRIPTION
Use PGID to kill all zombie child processe instead of just PID