### PR TITLE
Solve nested call monitor_cycle memory problem

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1236,7 +1236,8 @@ monitor_kill() {
 
 monitor_cycle() {
 	pgrep maldet > $tmpdir/monitor.pid
-	if [ ! -f "$tmpdir/stop_monitor" ]; then
+	inotify_cycle_runtime=0
+	while [ ! -f "$tmpdir/stop_monitor" ]; do
 		inotify_pid=`$pidof inotifywait`
 		if [ -z "$inotify_pid" ]; then
 			eout "{mon} no inotify process found, exiting (are we a zombie process?)" 1
@@ -1334,11 +1335,10 @@ monitor_cycle() {
 		sigignore 1
 		gensigs
 		monitor_check
-	else
+	done
 		rm -f $tmpdir/stop_monitor
 		eout "{mon} monitoring terminated by user, inotify killed."
 		exit
-	fi
 }
 
 monitor_check() {
@@ -1387,7 +1387,6 @@ monitor_check() {
 			eout "{mon} scanned ${scanned_count} new/changed files with native engine"
 			rm -f $clamscan_results $monitor_scanlist
 		fi
-		monitor_cycle
 }
 
 monitor_init() {


### PR DESCRIPTION
More info in rfxn/linux-malware-detect#106. This should prevent maldet consuming all the memory available in the system.
Variable `inotify_cycle_runtime` is initialized out of the new loop.