### PR TITLE
Accomodate Debians version of sysconfig

### DIFF
--- a/files/service/maldet.sh
+++ b/files/service/maldet.sh
@@ -25,6 +25,8 @@ elif [ -f /lib/lsb/init-functions ]; then
 fi
 if [ -f "/etc/sysconfig/maldet" ]; then
 	. /etc/sysconfig/maldet
+elif [ -f "/etc/default/maldet" ]; then
+    . /etc/default/maldet
 elif [ "$(egrep ^default_monitor_mode /usr/local/maldetect/conf.maldet 2> /dev/null)" ]; then
 	. /usr/local/maldetect/conf.maldet
 	if [ "$default_monitor_mode" ]; then


### PR DESCRIPTION
Debian has it's own version of sysconfig stored in /etc/default/.
