### PR TITLE
Pull in settings from sysconfig

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -13,6 +13,12 @@ else
 	exit 1
 fi
 
+if [ -f "/etc/sysconfig/maldet" ]; then
+	. /etc/sysconfig/maldet
+elif [ -f "/etc/default/maldet" ]; then
+	. /etc/default/maldet
+fi
+
 if [ -f "$cron_custom_conf" ]; then
 	. $cron_custom_conf
 fi


### PR DESCRIPTION
The cron should read settings from sysconfig, otherwise it will missing settings set there such as turning off auto update.
