### PR TITLE
Trying to reduce redundant paths definitions

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:$PATH
 export LMDCRON=1
-install_path=/usr/local/maldetect
+inspath=/usr/local/maldetect
 
 cron_custom_exec=$inspath/cron/custom.cron
 cron_custom_conf=$inspath/cron/conf.maldet.cron
 
-if [ -f "$install_path/conf.maldet" ]; then
-	. $install_path/conf.maldet
+if [ -f "$inspath/conf.maldet" ]; then
+	. $inspath/conf.maldet
 else
-	echo "could not find $install_path/conf.maldet, fatal error, bye."
+	echo "could not find $inspath/conf.maldet, fatal error, bye."
 	exit 1
 fi
 
@@ -30,7 +30,7 @@ fi
 find=`which find 2> /dev/null`
 if [ "$find" ]; then
 	# prune any quarantine/session/tmp data older than 7 days
-	tmpdirs="$install_path/tmp $install_path/sess $install_path/quarantine $install_path/pub"
+	tmpdirs="$inspath/tmp $inspath/sess $inspath/quarantine $inspath/pub"
 	for dir in $tmpdirs; do
 	 if [ -d "$dir" ]; then
 	  $find $dir -type f -mtime +7 -print0 | xargs -0 rm -f >> /dev/null 2>&1
@@ -45,45 +45,45 @@ fi
 
 if [ "$autoupdate_version" == "1" ]; then
 	# check for new release version
-	$install_path/maldet -d >> /dev/null 2>&1
+	$inspath/maldet -d >> /dev/null 2>&1
 fi
 
 if [ "$autoupdate_signatures" == "1" ]; then
 	# check for new definition set
-	$install_path/maldet -u >> /dev/null 2>&1
+	$inspath/maldet -u >> /dev/null 2>&1
 fi
 
 # if we're running inotify monitoring, send daily hit summary
 if [ "$(ps -A --user root -o "cmd" | grep maldetect | grep inotifywait)" ]; then
-        $install_path/maldet --monitor-report >> /dev/null 2>&1
+        $inspath/maldet --monitor-report >> /dev/null 2>&1
 else
 	if [ -d "/home/virtual" ] && [ -d "/usr/lib/opcenter" ]; then
 		# ensim
-	        $install_path/maldet -b -r /home/virtual/?/fst/var/www/html/,/home/virtual/?/fst/home/?/public_html/ $scan_days >> /dev/null 2>&1
+	        $inspath/maldet -b -r /home/virtual/?/fst/var/www/html/,/home/virtual/?/fst/home/?/public_html/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/etc/psa" ] && [ -d "/var/lib/psa" ]; then
 		# psa
-		$install_path/maldet -b -r /var/www/vhosts/?/ $scan_days >> /dev/null 2>&1
+		$inspath/maldet -b -r /var/www/vhosts/?/ $scan_days >> /dev/null 2>&1
         elif [ -d "/usr/local/directadmin" ]; then
                 # DirectAdmin
-                $install_path/maldet -b -r /home?/?/domains/?/public_html/,/var/www/html/?/ $scan_days >> /dev/null 2>&1
+                $inspath/maldet -b -r /home?/?/domains/?/public_html/,/var/www/html/?/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/var/www/clients" ]; then
 		# ISPConfig
-                $install_path/maldet -b -r /var/www/clients/?/web?/web,/var/www $scan_days >> /dev/null 2>&1
+                $inspath/maldet -b -r /var/www/clients/?/web?/web,/var/www $scan_days >> /dev/null 2>&1
 	elif [ -d "/etc/webmin/virtual-server" ]; then
 		# Virtualmin
-                $install_path/maldet -b -r /home/?/public_html/,/home/?/domains/?/public_html/ $scan_days >> /dev/null 2>&1
+                $inspath/maldet -b -r /home/?/public_html/,/home/?/domains/?/public_html/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/usr/local/ispmgr" ]; then
 		# ISPmanager
-		$install_path/maldet -b -r /var/www/?/data/,/home/?/data/ $scan_days >> /dev/null 2>&1
+		$inspath/maldet -b -r /var/www/?/data/,/home/?/data/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/var/customers/webs" ]; then
 		# froxlor
-		$install_path/maldet -b -r /var/customers/webs/ $scan_days >> /dev/null 2>&1
+		$inspath/maldet -b -r /var/customers/webs/ $scan_days >> /dev/null 2>&1
         elif [ -d "/usr/local/vesta" ]; then
                 # VestaCP
-                $install_path/maldet -b -r /home/?/web/?/public_html/,/home/?/web/?/public_shtml/,/home/?/tmp/,/home/?/web/?/private/ $scan_days >> /dev/null 2>&1
+                $inspath/maldet -b -r /home/?/web/?/public_html/,/home/?/web/?/public_shtml/,/home/?/tmp/,/home/?/web/?/private/ $scan_days >> /dev/null 2>&1
 	else
 		# cpanel, interworx and other standard home/user/public_html setups
-	        $install_path/maldet -b -r /home?/?/public_html/,/var/www/html/,/usr/local/apache/htdocs/ $scan_days >> /dev/null 2>&1
+	        $inspath/maldet -b -r /home?/?/public_html/,/var/www/html/,/usr/local/apache/htdocs/ $scan_days >> /dev/null 2>&1
 	fi
 fi
 

--- a/cron.daily
+++ b/cron.daily
@@ -2,14 +2,19 @@
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:$PATH
 export LMDCRON=1
 inspath=/usr/local/maldetect
+intcnf="$inspath/internals/internals.conf"
 
-cron_custom_exec=$inspath/cron/custom.cron
-cron_custom_conf=$inspath/cron/conf.maldet.cron
-
-if [ -f "$inspath/conf.maldet" ]; then
-	. $inspath/conf.maldet
+if [ -f "$intcnf" ]; then
+	source $intcnf
 else
-	echo "could not find $inspath/conf.maldet, fatal error, bye."
+	echo "$intcnf not found."
+	exit 1
+fi
+
+if [ -f "$cnf" ]; then
+	. $cnf
+else
+	echo "could not find $cnf, fatal error, bye."
 	exit 1
 fi
 
@@ -27,7 +32,6 @@ if [ -z "$scan_days" ]; then
 	scan_days=1
 fi
 
-find=`which find 2> /dev/null`
 if [ "$find" ]; then
 	# prune any quarantine/session/tmp data older than 7 days
 	tmpdirs="$inspath/tmp $inspath/sess $inspath/quarantine $inspath/pub"

--- a/files/hookscan.sh
+++ b/files/hookscan.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 file="$1"
+inspath=/usr/local/maldetect
+intcnf="$inspath/internals/internals.conf"
+
+if [ -f "$intcnf" ]; then
+	source $intcnf
+else
+	header
+	echo "maldet($$): {glob} $intcnf not found, aborting."
+	exit 1
+fi
+
 isclamd=`pidof clamd 2> /dev/null`
-clamdloc=`which clamdscan 2> /dev/null`
-if [ "$isclamd" ] && [ -f "$clamdloc" ]; then
+
+if [ "$isclamd" ] && [ -f "$clamdscan" ]; then
 	clamd_scan=1
 fi
-cd /tmp ; /usr/local/maldetect/maldet --config-option quarantine_hits=1,quarantine_clean=0,tmpdir=/var/tmp,scan_tmpdir_paths='',scan_clamscan=$clamd_scan --hook-scan -a "$file"
+cd /tmp ; $inspath//maldet --config-option quarantine_hits=1,quarantine_clean=0,tmpdir=/var/tmp,scan_tmpdir_paths='',scan_clamscan=$clamd_scan --hook-scan -a "$file"

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -16,7 +16,7 @@ prerun() {
 				exit
 			fi
 			header
-			echo "public scanning is currently disabled, please contact your system administrator to enable scan_user_access in conf.maldet."
+			echo "public scanning is currently disabled, please contact your system administrator to enable scan_user_access in $cnffile."
 			exit 1
 		fi
 		pub=1
@@ -190,7 +190,7 @@ trap_exit() {
 		eout "{glob} scan interrupt by user, aborting scan..." 1
 		eout "{scan} scan report saved, to view run: maldet --report $datestamp.$$" 1
 		if [ "$quarantine_hits" == "0" ] && [ ! "$tot_hits" == "0" ]; then
-			eout "{glob} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q $datestamp.$$" 1
+			eout "{glob} quarantine is disabled! set quarantine_hits=1 in $cnffile or to quarantine results run: maldet -q $datestamp.$$" 1
 		fi
 		exit
 	fi
@@ -386,7 +386,7 @@ usage $0 [ OPTION ]
        e.g: maldet --user nobody --restore 050910-1534.21135
 
     -co, --config-option VAR1=VALUE,VAR2=VALUE,VAR3=VALUE
-       Set or redefine the value of conf.maldet config options
+       Set or redefine the value of $cnffile config options
        e.g: maldet --config-option email_addr=you@domain.com,quarantine_hits=1
 
     -p, --purge
@@ -1037,7 +1037,7 @@ scan() {
 		eout "{scan} scan completed on $spath: files $tot_files, malware hits $tot_hits, cleaned hits $tot_cl, time ${scan_et}s" 1
 		eout "{scan} scan report saved, to view run: maldet --report $datestamp.$$" 1
 		if [ "$quarantine_hits" == "0" ] && [ ! "$tot_hits" == "0" ]; then
-			eout "{scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q $datestamp.$$" 1
+			eout "{scan} quarantine is disabled! set quarantine_hits=1 in $cnffile or to quarantine results run: maldet -q $datestamp.$$" 1
 		fi
 	fi
 	
@@ -1718,7 +1718,7 @@ lmdup() {
 			doupdate=1
 			elif [ "$autoupdate_version_hashed" == "1" ]; then
 			eout "{update} hashing install files and checking against server..." 1
-			$md5sum $inspath/maldet $inspath/internals/functions | awk '{print$1}' | tr '\n' ' ' | tr -d ' ' > $lmd_hash_file
+			$md5sum $inspath/maldet $intfunc | awk '{print$1}' | tr '\n' ' ' | tr -d ' ' > $lmd_hash_file
 			upstreamhash="$tmpwd/.lmdup_hashcheck$$"
 			$wget --referer="$lmd_referer" -q -T$wget_timeout -t$wget_retries "$lmd_hash_url" -O $upstreamhash >> /dev/null 2>&1
 			if [ -s "$upstreamhash" ]; then

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -6,6 +6,12 @@
 ##
 #
 
+inspath=/usr/local/maldetect
+intcnf="$inspath/internals/internals.conf"
+intfunc="$inspath/internals/functions"
+cnffile="conf.maldet"
+cnf="$inspath/$cnffile"
+
 logdir="$inspath/logs"
 maldet_log="$logdir/event_log"
 clamscan_log="$logdir/clamscan_log"
@@ -41,6 +47,7 @@ mail=`which mail 2> /dev/null`
 pidof=`which pidof 2> /dev/null`
 stat=`which stat 2> /dev/null`
 logger=`which logger 2> /dev/null`
+clamdscan=`which clamdscan 2> /dev/null`
 
 suppress_cleanhit="$email_ignore_clean"
 ignore_paths="$inspath/ignore_paths"
@@ -91,6 +98,9 @@ scan_user_access_minuid=40
 find_opts="-regextype posix-egrep"
 email_template="$inspath/internals/scan.etpl"
 email_subj="maldet alert from $(hostname)"
+
+cron_custom_exec="$inspath/cron/custom.cron"
+cron_custom_conf="$inspath/cron/conf.maldet.cron"
 
 ## backwards compatibility for pre-1.5 deprecated config options
 if [ ! "$quarantine_hits" ] && [ "$quar_hits" ]; then

--- a/files/maldet
+++ b/files/maldet
@@ -11,9 +11,7 @@ PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 ver=1.5
 
 inspath=/usr/local/maldetect
-cnf="$inspath/conf.maldet"
 intcnf="$inspath/internals/internals.conf"
-intfunc="$inspath/internals/functions"
 
 header() {
 	echo "Linux Malware Detect v$ver"
@@ -23,19 +21,19 @@ header() {
 	echo ""
 }
 
-if [ -f "$cnf" ]; then
-	source $cnf
-else
-	header
-	echo "maldet($$): {glob} $cnf not found, aborting."
-	exit 1
-fi
-
 if [ -f "$intcnf" ]; then
 	source $intcnf
 else
 	header
 	echo "maldet($$): {glob} $intcnf not found, aborting."
+	exit 1
+fi
+
+if [ -f "$cnf" ]; then
+	source $cnf
+else
+	header
+	echo "maldet($$): {glob} $cnf not found, aborting."
 	exit 1
 fi
 
@@ -83,7 +81,7 @@ else
 					exit
 				else
 					header
-					echo "public scanning support not enabled in conf.maldet, aborting."
+					echo "public scanning support not enabled in $cnf, aborting."
 					exit
 				fi
 			;;

--- a/files/service/maldet.sh
+++ b/files/service/maldet.sh
@@ -16,6 +16,15 @@
 # Short-Description: Start/stop maldet in monitor mode
 ### END INIT INFO
 
+inspath=/usr/local/maldetect
+intcnf="$inspath/internals/internals.conf"
+
+if [ -f "$intcnf" ]; then
+	source $intcnf
+else
+	echo "$intcnf not found."
+	exit 1
+fi
 
 # Source function library.
 if [ -f /etc/init.d/functions ]; then
@@ -27,8 +36,8 @@ if [ -f "/etc/sysconfig/maldet" ]; then
 	. /etc/sysconfig/maldet
 elif [ -f "/etc/default/maldet" ]; then
     . /etc/default/maldet
-elif [ "$(egrep ^default_monitor_mode /usr/local/maldetect/conf.maldet 2> /dev/null)" ]; then
-	. /usr/local/maldetect/conf.maldet
+elif [ "$(egrep ^default_monitor_mode $cnf 2> /dev/null)" ]; then
+	. $cnf
 	if [ "$default_monitor_mode" ]; then
 		MONITOR_MODE="$default_monitor_mode"
 	fi
@@ -43,18 +52,18 @@ fi
 
 if [ -z "$MONITOR_MODE" ]; then
     if [ -f /etc/redhat-release ]; then
-        echo "error no default monitor mode defined, set \$MONITOR_MODE in /etc/sysconfig/maldet, or \$default_monitor_mode in /usr/local/maldetect/conf.maldet"
+        echo "error no default monitor mode defined, set \$MONITOR_MODE in /etc/sysconfig/maldet, or \$default_monitor_mode in $cnf"
     elif [ -f /etc/debian_version ]; then
-        echo "error no default monitor mode defined, set \$MONITOR_MODE in /etc/default/maldet, or \$default_monitor_mode in /usr/local/maldetect/conf.maldet"
+        echo "error no default monitor mode defined, set \$MONITOR_MODE in /etc/default/maldet, or \$default_monitor_mode in $cnf"
     else
-        echo "error no default monitor mode defined, set \$MONITOR_MODE in /etc/sysconfig/maldet, or \$default_monitor_mode in /usr/local/maldetect/conf.maldet"
+        echo "error no default monitor mode defined, set \$MONITOR_MODE in /etc/sysconfig/maldet, or \$default_monitor_mode in $cnf"
     fi
 	exit 1
 fi
 
 start() {
         echo -n "Starting $prog: "
-        /usr/local/maldetect/maldet --monitor $MONITOR_MODE
+        $inspath/maldet --monitor $MONITOR_MODE
         RETVAL=$? [ $RETVAL -eq 0 ] && touch $LOCKFILE
         echo
         return $RETVAL
@@ -63,11 +72,11 @@ start() {
 stop() {
         echo -n "Shutting down $prog: "
         if [ -f /etc/redhat-release ]; then
-            /usr/local/maldetect/maldet --kill-monitor && success || failure
+            $inspath/maldet --kill-monitor && success || failure
         elif [ -f /etc/debian_version ]; then
-            /usr/local/maldetect/maldet --kill-monitor && log_success_msg || log_failure_msg
+            $inspath/maldet --kill-monitor && log_success_msg || log_failure_msg
         else
-            /usr/local/maldetect/maldet --kill-monitor && success || failure
+            $inspath/maldet --kill-monitor && success || failure
         fi
         RETVAL=$? [ $RETVAL -eq 0 ] && rm -f $LOCKFILE
         echo


### PR DESCRIPTION
There are several definitions of locations all over the files. This is
a try to reduce them and source them from the internals.conf. Some of
them are even hardcoded.

This effort tries to reduce the work when customized (eg. FHS compatible)
are used, for example downstream packaging.

A small amount of the hardcoded stuff is still untouched (installsh, maldet.sysconf and maldet.service) for obvious reasons.

Reducing the (hardcoded) locations is a first step to fix #137.