### PR TITLE
Remove unneeded inspath variable definition.

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:$PATH
 export LMDCRON=1
-inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 if [ -f "$intcnf" ]; then

--- a/files/hookscan.sh
+++ b/files/hookscan.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 file="$1"
-inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 if [ -f "$intcnf" ]; then

--- a/files/maldet
+++ b/files/maldet
@@ -10,7 +10,6 @@
 PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 ver=1.5
 
-inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 header() {

--- a/files/service/maldet.sh
+++ b/files/service/maldet.sh
@@ -16,7 +16,6 @@
 # Short-Description: Start/stop maldet in monitor mode
 ### END INIT INFO
 
-inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 if [ -f "$intcnf" ]; then


### PR DESCRIPTION
Since $inspath is defined in internals.conf and we source this, we don't
need to define it explicitly in this files.