### PR TITLE
Own variable libpath to separate libraries.

### DIFF
--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -8,7 +8,8 @@
 
 inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
-intfunc="$inspath/internals/functions"
+libpath="$inspath/internals"
+intfunc="$libpath/functions"
 
 logdir="$inspath/logs"
 confpath="$inspath"
@@ -88,17 +89,17 @@ lmd_hash_url="http://cdn.rfxn.com/downloads/maldet.current.hash"
 lmd_version_url="http://www.rfxn.com/downloads/maldet.current.ver"
 
 clamav_paths="/usr/local/cpanel/3rdparty/share/clamav/ /var/lib/clamav/ /var/clamav/ /usr/share/clamav/ /usr/local/share/clamav"
-tlog="$inspath/internals/tlog"
+tlog="$libpath/tlog"
 inotify=`which inotifywait 2> /dev/null`
 inotify_log="$inspath/logs/inotify_log"
 inotify_user_instances=128
 inotify_trim=150000
 hex_fifo_path="$varlibpath/internals/hexfifo"
-hex_fifo_script="$inspath/internals/hexfifo.pl"
-hex_string_script="$inspath/internals/hexstring.pl"
+hex_fifo_script="$libpath/hexfifo.pl"
+hex_string_script="$libpath/hexstring.pl"
 scan_user_access_minuid=40
 find_opts="-regextype posix-egrep"
-email_template="$inspath/internals/scan.etpl"
+email_template="$libpath/scan.etpl"
 email_subj="maldet alert from $(hostname)"
 
 cron_custom_exec="$confpath/cron/custom.cron"


### PR DESCRIPTION
Libraries for the binaries in /\*/bin/ and /\*/sbin/ should go into /\*/lib.
See https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard for example.

This is related to #137