### PR TITLE
Removing shebang from source files

### DIFF
--- a/.ca.def
+++ b/.ca.def
@@ -1,5 +1,4 @@
 cat > /usr/local/maldetect/conf.maldet <<EOF
-#!/bin/bash
 #
 ##
 # Linux Malware Detect v1.5

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1,4 +1,3 @@
-#!/bin/bash
 ##
 # Linux Malware Detect v1.5
 #             (C) 2002-2016, R-fx Networks <proj@r-fx.org>


### PR DESCRIPTION
The shebang is not needed for sourced files. At least [lintian](https://lintian.debian.org/) is [complaining](https://lintian.debian.org/tags/script-not-executable.html).