### PR TITLE
Revert "Remove unneeded inspath variable definition."

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:$PATH
 export LMDCRON=1
+inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 if [ -f "$intcnf" ]; then

--- a/files/hookscan.sh
+++ b/files/hookscan.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 file="$1"
+inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 if [ -f "$intcnf" ]; then

--- a/files/maldet
+++ b/files/maldet
@@ -10,6 +10,7 @@
 PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 ver=1.5
 
+inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 header() {

--- a/files/service/maldet.sh
+++ b/files/service/maldet.sh
@@ -16,6 +16,7 @@
 # Short-Description: Start/stop maldet in monitor mode
 ### END INIT INFO
 
+inspath=/usr/local/maldetect
 intcnf="$inspath/internals/internals.conf"
 
 if [ -f "$intcnf" ]; then


### PR DESCRIPTION
This reverts commit e29ee1881ae06a16cf06aed63faa8bc8fa603464.

(Fixes #150)