### PR TITLE
[Fix] legacy variable suppress_cleanhit references updated to email_i…

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -178,9 +178,9 @@ trap_exit() {
 		echo
 		gen_report
 		if [ ! "$tot_hits" == "0" ]; then
-			if [ "$suppress_cleanhit" == "1" ] && [ ! "$tot_hits" == "$tot_cl" ]; then
+			if [ "$email_ignore_clean" == "1" ] && [ ! "$tot_hits" == "$tot_cl" ]; then
 				genalert file $nsess
-				elif [ "$suppress_cleanhit" == "0" ]; then
+				elif [ "$email_ignore_clean" == "0" ]; then
 				genalert file $nsess
 			fi
 		fi
@@ -1041,9 +1041,9 @@ scan() {
 	fi
 	
 	if [ ! "$tot_hits" == "0" ]; then
-		if [ "$suppress_cleanhit" == "1" ] && [ ! "$tot_hits" == "$tot_cl" ]; then
+		if [ "$email_ignore_clean" == "1" ] && [ ! "$tot_hits" == "$tot_cl" ]; then
 			genalert file $nsess
-			elif [ "$suppress_cleanhit" == "0" ]; then
+		elif [ "$email_ignore_clean" == "0" ]; then
 			genalert file $nsess
 		fi
 	fi

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -52,7 +52,6 @@ stat=`which stat 2> /dev/null`
 logger=`which logger 2> /dev/null`
 clamdscan=`which clamdscan 2> /dev/null`
 
-suppress_cleanhit="$email_ignore_clean"
 ignore_paths="$confpath/ignore_paths"
 ignore_sigs="$confpath/ignore_sigs"
 ignore_inotify="$confpath/ignore_inotify"
@@ -101,119 +100,6 @@ scan_user_access_minuid=40
 find_opts="-regextype posix-egrep"
 email_template="$libpath/scan.etpl"
 email_subj="maldet alert from $(hostname)"
-
 cron_custom_exec="$confpath/cron/custom.cron"
 cron_custom_conf="$confpath/cron/conf.maldet.cron"
-
-## backwards compatibility for pre-1.5 deprecated config options
-if [ ! "$quarantine_hits" ] && [ "$quar_hits" ]; then
-       quarantine_hits="$quar_hits"
-fi
-if [ ! "$quarantine_clean" ] && [ "$quar_clean" ]; then
-       quarantine_clean="$quar_clean"
-fi
-if [ ! "$quarantine_suspend_user" ] && [ "$quar_susp" ]; then
-       quarantine_suspend_user="$quar_susp"
-fi
-if [ ! "$quarantine_suspend_user_minuid" ] && [ "$quar_susp_minuid" ]; then
-       quarantine_suspend_user_minuid="$quar_susp_minuid"
-fi
-if [ ! "$scan_max_depth" ] && [ "$maxdepth" ]; then
-       scan_max_depth="$maxdepth"
-fi
-if [ ! "$scan_min_filesize" ] && [ "$minfilesize" ]; then
-       scan_min_filesize="$minfilesize"
-fi
-if [ ! "$scan_max_filesize" ] && [ "$maxfilesize" ]; then
-       scan_max_filesize="$maxfilesize"
-fi
-if [ ! "$scan_hexdepth" ] && [ "$hexdepth" ]; then
-       scan_hexdepth="$hexdepth"
-fi
-if [ ! "$scan_hexfifo" ] && [ "$hex_fifo_scan" ]; then
-       scan_hexfifo="$hex_fifo_scan"
-fi
-if [ ! "$scan_hexfifo_depth" ] && [ "$hex_fifo_depth" ]; then
-       scan_hexfifo_depth="$hex_fifo_depth"
-fi
-if [ ! "$scan_clamscan" ] && [ "$clamav_scan" ]; then
-       scan_clamscan="$clamav_scan"
-fi
-if [ ! "$scan_tmpdir_paths" ] && [ "$tmpdir_paths" ]; then
-       scan_tmpdir_paths="$tmpdir_paths"
-fi
-if [ ! "$scan_user_access" ] && [ "$public_scan" ]; then
-       scan_user_access="$public_scan"
-fi
-if [ ! "$scan_user_access_minuid" ] && [ "$pubuser_minuid" ]; then
-       scan_user_access_minuid="$pubuser_minuid"
-fi
-if [ ! "$scan_cpunice" ] && [ "$scan_nice" ]; then
-       scan_cpunice="$scan_nice"
-fi
-if [ ! "$inotify_sleep" ] && [ "$inotify_stime" ]; then
-       inotify_sleep="$inotify_stime"
-fi
-if [ ! "$inotify_docroot" ] && [ "$inotify_webdir" ]; then
-       inotify_docroot="$inotify_webdir"
-fi
-if [ ! "$inotify_cpunice" ] && [ "$inotify_nice" ]; then
-       inotify_cpunice="$inotify_nice"
-fi
-if [ ! "$sig_version_file" ] && [ "$def_verf" ]; then
-       sig_version_file="$def_verf"
-fi
-if [ ! "$sig_version_url" ] && [ "$defurl_ver" ]; then
-       sig_version_url="$defurl_ver"
-fi
-if [ ! "$sig_version" ] && [ "$def_ver" ]; then
-       sig_version="$def_ver"
-fi
-if [ ! "$sig_sigpack_url" ] && [ "$defurl_sigpack" ]; then
-       sig_sigpack_url="$defurl_sigpack"
-fi
-if [ ! "$sig_clpack_url" ] && [ "$defurl_clpack" ]; then
-       sig_clpack_url="$defurl_clpack"
-fi
-if [ ! "$sig_md5_file" ] && [ "$dat_md5hash" ]; then
-       sig_md5_file="$dat_md5hash"
-fi
-if [ ! "$sig_hex_file" ] && [ "$dat_hexstring" ]; then
-       sig_hex_file="$dat_hexstring"
-fi
-if [ ! "$sig_cav_hex_file" ] && [ "$dat_hex_cav" ]; then
-       sig_cav_hex_file="$dat_hex_cav"
-fi
-if [ ! "$sig_cav_md5_file" ] && [ "$dat_md5_cav" ]; then
-       sig_cav_md5_file="$dat_md5_cav"
-fi
-if [ ! "$sig_cust_md5_file" ] && [ "$custdat_md5hash" ]; then
-       sig_cust_md5_file="$custdat_md5hash"
-fi
-if [ ! "$sig_cust_hex_file" ] && [ "$custdat_hexstring" ]; then
-       sig_cust_hex_file="$custdat_hexstring"
-fi
-if [ ! "$lmd_version_file" ] && [ "$lmd_verf" ]; then
-       lmd_version_file="$lmd_verf"
-fi
-if [ ! "$lmd_version" ] && [ "$lmd_ver" ]; then
-       lmd_version="$lmd_ver"
-fi
-if [ ! "$lmd_hash_file" ] && [ "$lmd_hashf" ]; then
-       lmd_hash_file="$lmd_hashf"
-fi
-if [ ! "$lmd_hash_url" ] && [ "$lmdurl_hash" ]; then
-       lmd_hash_url="$lmdurl_hash"
-fi
-if [ ! "$lmd_version_url" ] && [ "$lmdurl_ver" ]; then
-       lmd_version_url="$lmdurl_ver"
-fi
-if [ ! "$hex_fifo_path" ] && [ "$hex_fifo" ]; then
-       hex_fifo_path="$hex_fifo"
-fi
-if [ ! "$hex_string_script" ] && [ "$hexm_pl" ]; then
-       hex_string_script="$hexm_pl"
-fi
-if [ ! "$hex_fifo_script" ] && [ "$hexmfifo_pl" ]; then
-       hex_fifo_script="$hexmfifo_pl"
-fi
+compatcnf="$libpath/compat.conf"

--- a/files/maldet
+++ b/files/maldet
@@ -24,7 +24,7 @@ if [ -f "$intcnf" ]; then
 	source $intcnf
 else
 	header
-	echo "maldet($$): {glob} $intcnf not found, aborting."
+	echo "maldet($$): {glob} \$intcnf not found, aborting."
 	exit 1
 fi
 
@@ -32,7 +32,7 @@ if [ -f "$cnf" ]; then
 	source $cnf
 else
 	header
-	echo "maldet($$): {glob} $cnf not found, aborting."
+	echo "maldet($$): {glob} \$cnf not found, aborting."
 	exit 1
 fi
 
@@ -40,8 +40,12 @@ if [ -f "$intfunc" ]; then
 	source $intfunc
 else
 	header
-	echo "maldet($$): {glob} $intfunct not found, aborting."
+	echo "maldet($$): {glob} \$intfunct not found, aborting."
 	exit 1
+fi
+
+if [ -f "$compatcnf" ]; then
+	source $compatcnf
 fi
 
 # prerun operations


### PR DESCRIPTION
[Fix] legacy variable suppress_cleanhit references updated to email_ignore_clean
[Fix] email alerting broke due to order of precedence change of how configuration files were loaded
      and compatibility (legacy) variables being set before main conf.maldet was loaded; caused by
      FHS refactoring
[New] moved compatibility (legacy) variables out of internals.conf into compat.conf