### PR TITLE
a working freebsd detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ if [ -d "/etc/cron.d" ]; then
 	chmod 644 /etc/cron.d/maldet_pub
 fi
 
-if [ "$OSTYPE" != "FreeBSD" ]; then
+if [ "$(uname -s)" != "FreeBSD" ]; then
 	if test `cat /proc/1/comm` = "systemd"
 	then
 		mkdir -p /etc/systemd/system/


### PR DESCRIPTION
Hi,

this is the most minimal change possible for #66 in the installer.
It will use uname -s which means:

>   -s      Write the name of the operating system implementation to standard output"

I'll try to revisit freebsd support when i might be able to do more. (think: early '17)