### PR TITLE
Replace egrep with posix 'grep -e'

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -60,7 +60,7 @@ if [ "$autoupdate_signatures" == "1" ]; then
 fi
 
 # if we're running inotify monitoring, send daily hit summary
-if [ "$(ps -A --user root -o "cmd" | egrep maldetect | egrep inotifywait)" ]; then
+if [ "$(ps -A --user root -o "cmd" | grep -E maldetect | grep -E inotifywait)" ]; then
         $inspath/maldet --monitor-report >> /dev/null 2>&1
 else
 	if [ -d "/home/virtual" ] && [ -d "/usr/lib/opcenter" ]; then

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -164,7 +164,7 @@ prerun() {
 		nice_command="$nice_command $ionice -c2 -n $scan_ionice"
 	fi
 	if [ -f "$cpulimit" ] && [ "$scan_cpulimit" -gt 2> /dev/null "0" ]; then
-		max_cpulimit=$[$(egrep -w processor /proc/cpuinfo -c)*100]
+		max_cpulimit=$[$(grep -E -w processor /proc/cpuinfo -c)*100]
 		if [ "$scan_cpulimit" -gt "$max_cpulimit" ]; then
 			scan_cpulimit="0"
 		else
@@ -447,7 +447,7 @@ clean() {
 	sh_hitname=`echo $hitname | sed -e 's/{HEX}//' -e 's/{MD5}//' | tr '.' ' ' | awk '{print$1"."$2"."$3}'`
 	if [ -d "$cldir" ] && [ "$quarantine_clean" == "1" ] && [ "$quarantine_hits" == "1" ] && [ -f "$file" ]; then
 		if [ -f "$cldir/$sh_hitname" ] || [ -f "$cldir/custom.$sh_hitname" ] && [ -f "${file}.info" ]; then
-			file_path=`egrep -v '\#' ${file}.info | cut -d':' -f9`
+			file_path=`grep -E -v '\#' ${file}.info | cut -d':' -f9`
 			eout "{clean} restoring $file for cleaning attempt" $v
 			restore "$file" >> /dev/null 2>&1
 			if [ -f "$cldir/$sh_hitname" ]; then
@@ -506,23 +506,23 @@ restore() {
         file="$1"
         fname=`basename "$file"`
         if [ -f "$quardir/$file" ] && [ -f "$quardir/${file}.info" ]; then
-                file_owner=`egrep -v '\#' "$quardir/${file}.info" | awk -F':' '{print$1}'`
-                file_group=`egrep -v '\#' "$quardir/${file}.info" | awk -F':' '{print$2}'`
-                file_mode=`egrep -v '\#' "$quardir/${file}.info"  | awk -F':' '{print$3}'`
-                file_size=`egrep -v '\#' "$quardir/${file}.info"  | awk -F':' '{print$4}'`
-                md5_hash=`egrep -v '\#' "$quardir/${file}.info"   | awk -F':' '{print$5}'`
-                file_path=`egrep -v '\#' "$quardir/${file}.info"  | cut -d':' -f9`
+                file_owner=`grep -E -v '\#' "$quardir/${file}.info" | awk -F':' '{print$1}'`
+                file_group=`grep -E -v '\#' "$quardir/${file}.info" | awk -F':' '{print$2}'`
+                file_mode=`grep -E -v '\#' "$quardir/${file}.info"  | awk -F':' '{print$3}'`
+                file_size=`grep -E -v '\#' "$quardir/${file}.info"  | awk -F':' '{print$4}'`
+                md5_hash=`grep -E -v '\#' "$quardir/${file}.info"   | awk -F':' '{print$5}'`
+                file_path=`grep -E -v '\#' "$quardir/${file}.info"  | cut -d':' -f9`
                 chown ${file_owner}.${file_group} "$quardir/$file" >> /dev/null 2>&1
                 chmod $file_mode "$quardir/$file" >> /dev/null 2>&1
                 mv -f "$quardir/$file" "$file_path"
                 eout "{restore} quarantined file $file restored to $file_path" 1
         elif [ -f "$file" ] && [ -f "${file}.info" ]; then
-                file_owner=`egrep -v '\#' "${file}.info" | awk -F':' '{print$1}'`
-                file_group=`egrep -v '\#' "${file}.info" | awk -F':' '{print$2}'`
-                file_mode=`egrep -v '\#' "${file}.info"  | awk -F':' '{print$3}'`
-                file_size=`egrep -v '\#' "${file}.info"  | awk -F':' '{print$4}'`
-                md5_hash=`egrep -v '\#' "${file}.info"   | awk -F':' '{print$5}'`
-                file_path=`egrep -v '\#' "${file}.info"  | cut -d':' -f9`
+                file_owner=`grep -E -v '\#' "${file}.info" | awk -F':' '{print$1}'`
+                file_group=`grep -E -v '\#' "${file}.info" | awk -F':' '{print$2}'`
+                file_mode=`grep -E -v '\#' "${file}.info"  | awk -F':' '{print$3}'`
+                file_size=`grep -E -v '\#' "${file}.info"  | awk -F':' '{print$4}'`
+                md5_hash=`grep -E -v '\#' "${file}.info"   | awk -F':' '{print$5}'`
+                file_path=`grep -E -v '\#' "${file}.info"  | cut -d':' -f9`
                 chown ${file_owner}.${file_group} "$file" >> /dev/null 2>&1
                 chmod $file_mode "$file" >> /dev/null 2>&1
                 mv -f "$file" "$file_path"
@@ -536,7 +536,7 @@ restore_hitlist() {
 	hitlist="$sessdir/session.hits.$1"
 	if [ -f "$hitlist" ]; then
 		lbreakifs set
-		is_autoquar=`tail -n1 $hitlist | awk -F'>' '{print$2}' | egrep -v '^$' | sed 's/.//'`
+		is_autoquar=`tail -n1 $hitlist | awk -F'>' '{print$2}' | grep -E -v '^$' | sed 's/.//'`
 		if [ "$is_autoquar" ]; then
 			for file in `cat $hitlist | cut -d':' -f2 | cut -d'>' -f2 | sed 's/.//'`; do
 				if [ -f "$file" ]; then
@@ -545,7 +545,7 @@ restore_hitlist() {
 			done
 		elif [ ! "$is_autoquar" ]; then
 			for file in `cat $hitlist | cut -d':' -f2 | sed 's/.//'`; do
-				quar_file=`cat $quar_history | egrep -w "$file" | cut -d':' -f8 | tail -n1`
+				quar_file=`cat $quar_history | grep -E -w "$file" | cut -d':' -f8 | tail -n1`
 				restore "$quar_file"
 			done
 		else
@@ -910,7 +910,7 @@ scan() {
 	
 	hex_sigs=`$wc -l $sig_hex_file | awk '{print$1}'`
 	md5_sigs=`$wc -l $sig_md5_file | awk '{print$1}'`
-	yara_sigs=`egrep -c ^rule $sig_yara_file | awk '{print$1}'`
+	yara_sigs=`grep -E -c ^rule $sig_yara_file | awk '{print$1}'`
 	custhex_sigs=`$wc -l $sig_cust_hex_file | awk '{print$1}'`
 	custmd5_sigs=`$wc -l $sig_cust_md5_file | awk '{print$1}'`
 	cust_sigs=$[custhex_sigs+custmd5_sigs]
@@ -955,7 +955,7 @@ scan() {
 	fi
 		
 	if [ "$file_list" ]; then
-		cat $file_list | egrep -vf $ignore_paths > $find_results
+		cat $file_list | grep -E -vf $ignore_paths > $find_results
 	else
 		if [ "$single_filescan" ]; then
 			find_recentops=""
@@ -988,7 +988,7 @@ scan() {
 		tmpscandir="$tmpdir/scan.$RANDOM"
 		mkdir -p "$tmpscandir" ; chmod 700 $tmpscandir ; cd $tmpscandir
 		eout "{scan} executed eval $nice_command $find $spath $spath_tmpdirs -maxdepth $scan_max_depth $find_opts -type f $find_recentopts -size +${scan_min_filesize}c -size -$scan_max_filesize $include_regex -not -perm 000 $exclude_regex $ignore_fext $ignore_root $ignore_user $ignore_group"
-		eval $nice_command $find /lmd_find/ $(echo $spath) $spath_tmpdirs -maxdepth $scan_max_depth $find_opts -type f $find_recentopts -size +${scan_min_filesize}c -size -$scan_max_filesize $include_regex -not -perm 000 $exclude_regex $ignore_fext $ignore_root $ignore_user $ignore_group 2> /dev/null | egrep -vf $ignore_paths > $find_results
+		eval $nice_command $find /lmd_find/ $(echo $spath) $spath_tmpdirs -maxdepth $scan_max_depth $find_opts -type f $find_recentopts -size +${scan_min_filesize}c -size -$scan_max_filesize $include_regex -not -perm 000 $exclude_regex $ignore_fext $ignore_root $ignore_user $ignore_group 2> /dev/null | grep -E -vf $ignore_paths > $find_results
 		cd $tmpdir
 		rm -rf $tmpscandir
 		if [ "$rscan" = "1" ] && [ "$LMDCRON" == "1" ] && [ "$scan_export_filelist" == "1" ]; then
@@ -1061,15 +1061,15 @@ scan() {
 			echo "$(date +"%b %d %H:%M:%S") $(hostname -s) clamscan end"  >> $clamscan_log
 		fi
 		lbreakifs set
-		for hit in `egrep -v 'ERROR$|lstat()' $clamscan_results | sed -e 's/.UNOFFICIAL//' -e 's/ FOUND$//' | awk -F':' '{print$2":"$1}' | sed 's/.//'`; do
+		for hit in `grep -E -v 'ERROR$|lstat()' $clamscan_results | sed -e 's/.UNOFFICIAL//' -e 's/ FOUND$//' | awk -F':' '{print$2":"$1}' | sed 's/.//'`; do
 			file=`echo "$hit" | cut -d':' -f2`
 			signame=`echo "$hit" | cut -d':' -f1`
-			if [ ! -z "$(echo $signame | egrep 'YARA')" ]; then
+			if [ ! -z "$(echo $signame | grep -E 'YARA')" ]; then
                                 signame=`echo "$signame" | sed 's/YARA\./{YARA}/'`
-                        elif [ -z "$(echo $signame | egrep 'HEX|MD5')" ]; then
+                        elif [ -z "$(echo $signame | grep -E 'HEX|MD5')" ]; then
                                 signame="{CAV}$signame"
 			fi
-			ignore_hit=`echo $signame | egrep -vf $ignore_sigs`
+			ignore_hit=`echo $signame | grep -E -vf $ignore_sigs`
 			if [ ! -z "$ignore_hit" ]; then
 			 record_hit "$file" "$signame"
 			 quarantine "$file" "$signame"
@@ -1284,7 +1284,7 @@ genalert() {
 				fi
 			fi
 		elif [ "$type" == "daily" ] || [ "$type" == "digest" ]; then
-			scan_start_hr=`ps -p $(ps -A -o 'pid cmd' | egrep maldetect | egrep inotifywait | awk '{print$1}' | head -n1) -o lstart= 2> /dev/null`
+			scan_start_hr=`ps -p $(ps -A -o 'pid cmd' | grep -E maldetect | grep -E inotifywait | awk '{print$1}' | head -n1) -o lstart= 2> /dev/null`
 			rm -f $tmpdir/.digest.alert.hits $tmpdir/.digest.clean.hits $tmpdir/.digest.monitor.alert $tmpdir/.digest.susp.hits
 			scanid="$datestamp.$$"
 			scan_session=`cat $sessdir/session.monitor.current`
@@ -1311,7 +1311,7 @@ genalert() {
 				fi
 				. $email_template
 				cp $tmpf $sessdir/session.$scanid
-				egrep '^{.*}' $sessdir/session.$scanid > $sessdir/session.hits.$scanid
+				grep -E '^{.*}' $sessdir/session.$scanid > $sessdir/session.hits.$scanid
 				echo "$scanid" > $sessdir/session.last
 				email_subj="${email_subj}: monitor summary"
 				cat $tmpf | $mail -s "$email_subj" $email_addr
@@ -1419,7 +1419,7 @@ monitor_cycle() {
 monitor_check() {
                 monitor_scanlist="$tmpdir/.monitor.scan.${RANDOM}${RANDOM}"
 		touch $monitor_scanlist ; chmod 600 $monitor_scanlist
-		$tlog $inotify_log inotify | grep -E "CREATE|MODIFY|MOVED_FROM|MOVED_TO" | egrep -v '/.. ' | awk '{print$1}' | sort | uniq > $monitor_scanlist
+		$tlog $inotify_log inotify | grep -E "CREATE|MODIFY|MOVED_FROM|MOVED_TO" | grep -E -v '/.. ' | awk '{print$1}' | sort | uniq > $monitor_scanlist
 		if [ "$scan_clamscan" == "1" ]; then
 	                clamscan_results="$tmpdir/.clamscan.result.${RANDOM}${RANDOM}"
 			touch $clamscan_results ; chmod 600 $clamscan_results
@@ -1431,15 +1431,15 @@ monitor_check() {
 				done
 			fi
 			lbreakifs set
-                	for hit in `egrep -v 'ERROR$|lstat()' $clamscan_results | sed -e 's/.UNOFFICIAL//' -e 's/ FOUND$//' | awk -F':' '{print$2":"$1}' | sed 's/.//'`; do
+                	for hit in `grep -E -v 'ERROR$|lstat()' $clamscan_results | sed -e 's/.UNOFFICIAL//' -e 's/ FOUND$//' | awk -F':' '{print$2":"$1}' | sed 's/.//'`; do
 	                        file=`echo "$hit" | cut -d':' -f2`
         	                signame=`echo "$hit" | cut -d':' -f1`
-	                        if [ ! -z "$(echo $signame | egrep 'YARA')" ]; then
+	                        if [ ! -z "$(echo $signame | grep -E 'YARA')" ]; then
                         	        signame=`echo "$signame" | sed 's/YARA\./{YARA}/'`
-                	        elif [ -z "$(echo $signame | egrep 'HEX|MD5')" ]; then
+                	        elif [ -z "$(echo $signame | grep -E 'HEX|MD5')" ]; then
         	                        signame="{CAV}$signame"
 	                        fi
-	                        ignore_hit=`echo $signame | egrep -vf $ignore_sigs`
+	                        ignore_hit=`echo $signame | grep -E -vf $ignore_sigs`
 				if [ -f "$file" ] && [ ! -z "$ignore_hit" ]; then
 	                        	record_hit "$file" "$signame"
 	        	                quarantine "$file" "$signame"
@@ -1630,7 +1630,7 @@ monitor_init() {
                 nice_command="$nice_command $ionice -c2 -n $inotify_ionice"
         fi
         if [ -f "$cpulimit" ] && [ "$inotify_cpulimit" -gt 2> /dev/null "0" ]; then
-                max_cpulimit=$[$(egrep -w processor /proc/cpuinfo -c)*100]
+                max_cpulimit=$[$(grep -E -w processor /proc/cpuinfo -c)*100]
                 if [ "$inotify_cpulimit" -gt "$max_cpulimit" ]; then
                         scan_cpulimit="0"
 		else
@@ -1760,9 +1760,9 @@ sigignore() {
 	sil="$1"
 	chk=`$wc -l $ignore_sigs | awk '{print$1}'`
 	if [ ! "$chk" == "0" ]; then
-		cat $sig_hex_file | egrep -vf $ignore_sigs > $sig_hex_file.new
+		cat $sig_hex_file | grep -E -vf $ignore_sigs > $sig_hex_file.new
 		mv $sig_hex_file.new $sig_hex_file
-		cat $sig_md5_file | egrep -vf $ignore_sigs > $sig_md5_file.new
+		cat $sig_md5_file | grep -E -vf $ignore_sigs > $sig_md5_file.new
 		mv $sig_md5_file.new $sig_md5_file
 		chmod 640 $sig_md5_file $sig_hex_file
 		if [ "$sil" == "1" ] || [ "$hscan" == "1" ]; then
@@ -1994,7 +1994,7 @@ sigup() {
 			
 			hex_sigs=`$wc -l $sig_hex_file | awk '{print$1}'`
 			md5_sigs=`$wc -l $sig_md5_file | awk '{print$1}'`
-			yara_sigs=`egrep -c ^rule $sig_yara_file | awk '{print$1}'`
+			yara_sigs=`grep -E -c ^rule $sig_yara_file | awk '{print$1}'`
 			if [ ! -f "$sig_cust_md5_file" ]; then
 				custhex_sigs=0
 			else

--- a/files/service/maldet.sh
+++ b/files/service/maldet.sh
@@ -35,7 +35,7 @@ if [ -f "/etc/sysconfig/maldet" ]; then
 	. /etc/sysconfig/maldet
 elif [ -f "/etc/default/maldet" ]; then
 	. /etc/default/maldet
-elif [ "$(egrep ^default_monitor_mode $cnf 2> /dev/null)" ]; then
+elif [ "$(grep -E ^default_monitor_mode $cnf 2> /dev/null)" ]; then
 	. $cnf
 	if [ "$default_monitor_mode" ]; then
 		MONITOR_MODE="$default_monitor_mode"


### PR DESCRIPTION
From the grep manpage:

   -E, --extended-regexp
          Interpret PATTERN as an extended regular  expression  (ERE,  see
          below).  (-E is specified by POSIX.)

Direct invocation as either egrep or fgrep is deprecated, but is provided to
allow historical applications that rely on them to run unmodified.