### PR TITLE
Fix inotifywait exclude.

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1678,10 +1678,10 @@ monitor_init() {
 				if [ "$igregexp" ]; then
 					igregexp="$igregexp|$igfile"
 				else
-					igregexp="\($igfile"
+					igregexp="($igfile"
 				fi
 			done
-			igregexp="$igregexp\)"
+			igregexp="$igregexp)"
 			exclude="--exclude $igregexp"
 		fi
 	fi


### PR DESCRIPTION
inotifywait is using POSIX extended regular expression for exclude.

From man page:

```
--exclude <pattern>
Do not process any events whose filename matches the specified POSIX extended regular expression, case sensitive.
```

Fix #205 