### PR TITLE
Systemd maldet.service should source a value for default_monitor_mode.

### DIFF
--- a/files/conf.maldet
+++ b/files/conf.maldet
@@ -203,9 +203,15 @@ quarantine_suspend_user_minuid="500"
 # [ MONITORING OPTIONS ]
 ##
 # The default startup option for monitor mode, either 'users' or path to line
-# spaced file containing local paths to monitor. This option is used for the
-# init based startup script. This value is ignored when '/etc/sysconfig/maldet'
-# or '/etc/default/maldet' is present with a defined value for $MONITOR_MODE.
+# spaced file containing local paths to monitor.
+#
+# This option is optional for the init based startup script, maldet.sh. This
+# value is ignored when '/etc/sysconfig/maldet' or '/etc/default/maldet' is
+# present with a defined value for $MONITOR_MODE.
+#
+# This option is REQUIRED for the systemd maldet.service script. That script
+# only checks for the value of $default_monitor_mode. The service will fail to
+# start if a value is not provided.
 # default_monitor_mode="users"
 # default_monitor_mode="/usr/local/maldetect/monitor_paths"
 

--- a/files/service/maldet.service
+++ b/files/service/maldet.service
@@ -3,7 +3,8 @@ Description=Linux Malware Detect monitoring - maldet
 After=network.target
 
 [Service]
-ExecStart=/usr/local/maldetect/maldet --monitor /usr/local/maldetect/monitor_paths
+EnvironmentFile=/usr/local/maldetect/conf.maldet
+ExecStart=/usr/local/maldetect/maldet --monitor $default_monitor_mode
 ExecStop=/usr/local/maldetect/maldet --kill-monitor
 Type=forking
 PIDFile=/usr/local/maldetect/tmp/inotifywait.pid


### PR DESCRIPTION
The current maldet.service script always starts maldet in monitor mode using
the monitor_paths file. Let's set the monitor mode based on the value for
$default_monitor_mode sourced from conf.maldet.

I don't know if there's a way to do the same IF structure found in maldet.sh in
a systemd unit. We're stuck with relying solely on conf.maldet, since
/etc/sysconfig/maldet is setting a value for a different variable,
$MONITOR_MODE.

Resource:
https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html