### PR TITLE
fix maldet not scanning addon/subdomain not in public_html path in cP…

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -69,37 +69,40 @@ if [ "$(ps -A --user root -o "cmd" | grep -E maldetect | grep -E inotifywait)" ]
 else
 	if [ -d "/home/virtual" ] && [ -d "/usr/lib/opcenter" ]; then
 		# ensim
-	        $inspath/maldet -b -r /home/virtual/?/fst/var/www/html/,/home/virtual/?/fst/home/?/public_html/ $scan_days >> /dev/null 2>&1
+    $inspath/maldet -b -r /home/virtual/?/fst/var/www/html/,/home/virtual/?/fst/home/?/public_html/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/etc/psa" ] && [ -d "/var/lib/psa" ]; then
 		# psa
 		$inspath/maldet -b -r /var/www/vhosts/?/ $scan_days >> /dev/null 2>&1
-        elif [ -d "/usr/local/directadmin" ]; then
-                # DirectAdmin
-                $inspath/maldet -b -r /home?/?/domains/?/public_html/,/var/www/html/?/ $scan_days >> /dev/null 2>&1
+  elif [ -d "/usr/local/directadmin" ]; then
+    # DirectAdmin
+    $inspath/maldet -b -r /home?/?/domains/?/public_html/,/var/www/html/?/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/var/www/clients" ]; then
 		# ISPConfig
-                $inspath/maldet -b -r /var/www/clients/?/web?/web,/var/www/clients/?/web?/subdomains,/var/www $scan_days >> /dev/null 2>&1
+    $inspath/maldet -b -r /var/www/clients/?/web?/web,/var/www/clients/?/web?/subdomains,/var/www $scan_days >> /dev/null 2>&1
 	elif [ -d "/etc/webmin/virtual-server" ]; then
 		# Virtualmin
-                $inspath/maldet -b -r /home/?/public_html/,/home/?/domains/?/public_html/ $scan_days >> /dev/null 2>&1
+    $inspath/maldet -b -r /home/?/public_html/,/home/?/domains/?/public_html/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/usr/local/ispmgr" ]; then
 		# ISPmanager
 		$inspath/maldet -b -r /var/www/?/data/,/home/?/data/ $scan_days >> /dev/null 2>&1
 	elif [ -d "/var/customers/webs" ]; then
 		# froxlor
 		$inspath/maldet -b -r /var/customers/webs/ $scan_days >> /dev/null 2>&1
-        elif [ -d "/usr/local/vesta" ]; then
-                # VestaCP
-                $inspath/maldet -b -r /home/?/web/?/public_html/,/home/?/web/?/public_shtml/,/home/?/tmp/,/home/?/web/?/private/ $scan_days >> /dev/null 2>&1
-        elif [ -d "/usr/share/dtc" ]; then
-                # DTC
-                if [ -f /var/lib/dtc/saved_install_config ]; then
-                    . /var/lib/dtc/saved_install_config
-                fi
-                $inspath/maldet -b -r ${conf_hosting_path:-/var/www/sites}/?/?/subdomains/?/html/ $scan_days >> /dev/null 2>&1
+  elif [ -d "/usr/local/vesta" ]; then
+    # VestaCP
+    $inspath/maldet -b -r /home/?/web/?/public_html/,/home/?/web/?/public_shtml/,/home/?/tmp/,/home/?/web/?/private/ $scan_days >> /dev/null 2>&1
+  elif [ -d "/usr/share/dtc" ]; then
+    # DTC
+    if [ -f /var/lib/dtc/saved_install_config ]; then
+        . /var/lib/dtc/saved_install_config
+    fi
+    $inspath/maldet -b -r ${conf_hosting_path:-/var/www/sites}/?/?/subdomains/?/html/ $scan_days >> /dev/null 2>&1
+	elif [ -d "/var/cpanel" ];then
+		# cpanel
+		$inspath/maldet -b -r /home?/?/public_html/,$(cat /etc/userdatadomains|awk -F '==' '{print $5}'|grep -v 'public_html')/var/www/html/,/usr/local/apache/htdocs/ $scan_days >> /dev/null 2>&1
 	else
 		# cpanel, interworx and other standard home/user/public_html setups
-	        $inspath/maldet -b -r /home?/?/public_html/,/var/www/html/,/usr/local/apache/htdocs/ $scan_days >> /dev/null 2>&1
+	  $inspath/maldet -b -r /home?/?/public_html/,/var/www/html/,/usr/local/apache/htdocs/ $scan_days >> /dev/null 2>&1
 	fi
 fi
 


### PR DESCRIPTION
I have added a small change so it adds the path for addon/subdomain in cpanel with path like 
/home/user/xyz . The current scan only takes care of path like /home/user/public_html/xyz
