### PR TITLE
Rework installer script to enable options to make for easier packaging.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,52 +9,77 @@
 #
 PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 ver=1.6
+prefix=
 inspath=/usr/local/maldetect
-logf=$inspath/logs/event_log
+binpath=/usr/local
 conftemp="$inspath/internals/importconf"
-find=`which find 2> /dev/null`
+clamav=
+clamav_paths="/usr/local/cpanel/3rdparty/share/clamav/ /var/lib/clamav/ /var/clamav/ /usr/share/clamav/ /usr/local/share/clamav"
+autostart=1
 
+T=$(getopt -o "" --long "prefix:,installdir:,binprefix:,with-clamav::,no-clamav,autostart,no-autostart,errexit" -n "$0" -- "$@")
+eval set -- "${T}"
 
-clamav_linksigs() {
-        cpath="$1"
-        if [ -d "$cpath" ]; then
-                rm -f $cpath/rfxn.* ; cp -f $inspath/sigs/rfxn.ndb $inspath/sigs/rfxn.hdb $cpath/ 2> /dev/null
-                rm -f $cpath/lmd.user.* ; cp -f $inspath/sigs/lmd.user.ndb $inspath/sigs/lmd.user.hdb $cpath/ 2> /dev/null
-        fi
-}
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--prefix)
+			prefix="$2"
+			shift 2
+			;;
+		--installdir)
+			inspath="$2"
+			shift 2
+			;;
+		--binprefix)
+			binpath="$2"
+			shift 2
+			;;
+		--no-clamav)
+			clamav="-"
+			shift
+			;;
+		--with-clamav)
+			clamav="$2"
+			shift 2
+			;;
+		--no-autostart)
+			autostart=
+			shift
+			;;
+		--autostart)
+			autostart=1
+			shift
+			;;
+		--errexit)
+			set -o errexit
+			shift
+			;;
+		--)
+			shift $#
+			;;
+		*)
+			echo "Invalid option ($1) supplied." >&2
+			exit 1
+		;;
+	esac
+done
 
-if [ ! -d "$inspath" ] && [ -d "files" ]; then
-	mkdir -p $inspath
-	chmod 755 $inspath
-	cp -pR files/* $inspath
-	chmod 755 $inspath/maldet
-	mkdir -p $inspath/clean $inspath/pub $inspath/quarantine $inspath/sess $inspath/sigs $inspath/tmp 2> /dev/null
-	chmod 750 $inspath/quarantine $inspath/sess $inspath/tmp $inspath/internals/tlog 2> /dev/null
-	ln -fs $inspath/maldet /usr/local/sbin/maldet
-	ln -fs $inspath/maldet /usr/local/sbin/lmd
-	cp -f CHANGELOG COPYING.GPL README $inspath/
-	clamav_paths="/usr/local/cpanel/3rdparty/share/clamav/ /var/lib/clamav/ /var/clamav/ /usr/share/clamav/ /usr/local/share/clamav"
-	for lp in $clamav_paths; do
-		clamav_linksigs "$lp"
+logf="${inspath}/logs/event_log"
+
+if [ -z "${clamav}" ]; then
+	for lp in ${clamav_paths}; do
+		[ -d "${lp}" ] && clamav="${lp}" && break
 	done
-	killall -SIGUSR2 clamd 2> /dev/null
-else
+fi
+
+if [ -z "${prefix}" -a -d "$inspath" ]; then
 	if [ "$(ps -A --user root -o "cmd" 2> /dev/null | grep maldetect | grep inotifywait)" ]; then
 		$inspath/maldet -k >> /dev/null 2>&1
 		monmode=1
 	fi
-	$find ${inspath}.* -maxdepth 0 -type d -mtime +30 2> /dev/null | xargs rm -rf
-	mv $inspath $inspath.bk$$
-	ln -fs $inspath.bk$$ $inspath.last
-	mkdir -p $inspath
-	chmod 755 $inspath
-	cp -pR files/* $inspath
-	chmod 755 $inspath/maldet
-	ln -fs $inspath/maldet /usr/local/sbin/maldet
-	ln -fs $inspath/maldet /usr/local/sbin/lmd
-	mkdir -p /usr/local/share/man/man1/
-	gzip -9 $inspath/maldet.1
-	ln -fs $inspath/maldet.1.gz /usr/local/share/man/man1/maldet.1.gz
+	find "${inspath}".* -maxdepth 0 -type d -mtime +30 2> /dev/null | xargs rm -rf
+	mv "${inspath}" "${inspath}.bk$$"
+	ln -fs "$(basename "$inspath.bk$$")" "${inspath}.last"
 	cp -f $inspath.bk$$/ignore_* $inspath/  >> /dev/null 2>&1
 	if [ "$ver" == "1.5" ] || [ "$ver" == "1.6" ]; then
 		cp -f $inspath.bk$$/sess/* $inspath/sess/ >> /dev/null 2>&1
@@ -65,27 +90,63 @@ else
 	cp -f $inspath.bk$$/sigs/custom.* $inspath/sigs/ >> /dev/null 2>&1
 	cp -f $inspath.bk$$/monitor_paths $inspath/ >> /dev/null 2>&1
 	cp -pf $inspath.bk$$/clean/custom.* $inspath/clean/ >> /dev/null 2>&1
-	cp -f CHANGELOG COPYING.GPL README $inspath/
-	mkdir -p $inspath/clean $inspath/pub $inspath/quarantine $inspath/sess $inspath/sigs $inspath/tmp 2> /dev/null
-	chmod 750 $inspath/quarantine $inspath/sess $inspath/tmp $inspath/internals/tlog 2> /dev/null
-	clamav_paths="/usr/local/cpanel/3rdparty/share/clamav/ /var/lib/clamav/ /var/clamav/ /usr/share/clamav/ /usr/local/share/clamav"
-	for lp in $clamav_paths; do
-		clamav_linksigs "$lp"
-	done
-	killall -SIGUSR2 clamd 2> /dev/null
+fi
+
+mkdir -p "$prefix/$inspath"
+chmod 755 "$prefix/$inspath"
+cp -pR files/* "$prefix/$inspath"
+chmod 755 "$prefix/$inspath/maldet"
+mkdir -p "$prefix/$inspath/"{clean,pub,quarantine,sess,sigs,tmp}
+chmod 750 "$prefix/$inspath/"{quarantine,sess,tmp,internals/tlog}
+gzip -9 "${prefix}$inspath/maldet.1"
+cp -f CHANGELOG COPYING.GPL README "${prefix}/$inspath/"
+
+if [ -n "${binpath}" ]; then
+	mkdir -p "${prefix}${binpath}/sbin"
+	ln -fs ${inspath}/maldet "${prefix}/${binpath}/sbin/maldet"
+	ln -fs ${inspath}/maldet "${prefix}/${binpath}/sbin/lmd"
+
+	mkdir -p "${prefix}${binpath}/share/man/man1/"
+	ln -fs "${inspath}/maldet.1.gz" "${prefix}${binpath}/share/man/man1/maldet.1.gz"
+fi
+
+
+if [ -z "${prefix}" -a -d "${inspath}.bk$$" ]; then
+	cp -f "${inspath}.bk$$"/ignore_* "${inspath}/" &>/dev/null
+	if [ "$ver" == "1.5" ] || [ "$ver" == "1.6" ]; then
+		cp -f $inspath.bk$$/sess/* $inspath/sess/ >> /dev/null 2>&1
+		cp -f $inspath.bk$$/tmp/* $inspath/tmp/ >> /dev/null 2>&1
+		cp -f $inspath.bk$$/quarantine/* $inspath/quarantine/ >> /dev/null 2>&1
+                cp -f $inspath.bk$$/cron/* $inspath/cron/
+	fi
+	cp -f $inspath.bk$$/sigs/custom.* $inspath/sigs/ >> /dev/null 2>&1
+	cp -f $inspath.bk$$/monitor_paths $inspath/ >> /dev/null 2>&1
+	cp -pf $inspath.bk$$/clean/custom.* $inspath/clean/ >> /dev/null 2>&1
+fi
+
+if [ "${clamav}" != "-" -a -d "${clamav}" ]; then
+	mkdir -p "${prefix}${clamav}"
+	[ -z "${prefix}" ] && rm -f "$clamav"/{lmd.user,rfxn}.*
+
+	ln -sf $inspath/sigs/rfxn.ndb $inspath/sigs/rfxn.hdb "${prefix}${clamav}/"
+	ln -sf $inspath/sigs/lmd.user.ndb $inspath/sigs/lmd.user.hdb "${prefix}${clamav}/"
+
+	[ -z "${prefix}" ] && killall -SIGUSR2 clamd 2> /dev/null
 fi
 
 if [ -d "/etc/cron.daily" ]; then
-	cp -f cron.daily /etc/cron.daily/maldet
-	chmod 755 /etc/cron.daily/maldet
+	mkdir -p "${prefix}/etc/cron.daily"
+	cp -f cron.daily "${prefix}/etc/cron.daily/maldet"
+	chmod 755 "${prefix}/etc/cron.daily/maldet"
 fi
 
 if [ -d "/etc/cron.d" ]; then
-	cp -f cron.d.pub /etc/cron.d/maldet_pub
-	chmod 644 /etc/cron.d/maldet_pub
+	mkdir -p "${prefix}/etc/cron.d"
+	cp -f cron.d.pub "${prefix}/etc/cron.d/maldet_pub"
+	chmod 644 "${prefix}/etc/cron.d/maldet_pub"
 fi
 
-if [ "$(uname -s)" != "FreeBSD" ]; then
+if [ "$(uname -s)" != "FreeBSD" -a -n "${autostart}" ]; then
         if test "$(cat /proc/1/comm 2> /dev/null)" == "systemd"
         then
                 mkdir -p /etc/systemd/system/
@@ -122,9 +183,9 @@ if [ "$(uname -s)" != "FreeBSD" ]; then
 	fi
 fi
 
-mkdir -p $inspath/logs && touch $logf
-ln -fs $logf $inspath/event_log
-$inspath/maldet --alert-daily 2> /dev/null
+mkdir -p "${prefix}$inspath/logs" && touch "${prefix}${logf}"
+ln -fs "${logf}" "${prefix}${inspath}/event_log"
+[ -z "${prefix}" ] && $inspath/maldet --alert-daily 2> /dev/null
 
 echo "Linux Malware Detect v$ver"
 echo "            (C) 2002-2017, R-fx Networks <proj@r-fx.org>"
@@ -137,24 +198,26 @@ echo "exec file: $inspath/maldet"
 echo "exec link: /usr/local/sbin/maldet"
 echo "exec link: /usr/local/sbin/lmd"
 echo "cron.daily: /etc/cron.daily/maldet"
-if [ -f "$conftemp" ] && [ -f "${inspath}.last/conf.maldet" ]; then
-	. files/conf.maldet
-	. ${inspath}.last/conf.maldet
-	if [ "$quarantine_hits" == "0" ] && [ "$quar_hits" == "1" ]; then
-		quarantine_hits=1
+if [ -z "${prefix}" ]; then
+	if [ -f "$conftemp" ] && [ -f "${inspath}.last/conf.maldet" ]; then
+		. files/conf.maldet
+		. ${inspath}.last/conf.maldet
+		if [ "$quarantine_hits" == "0" ] && [ "$quar_hits" == "1" ]; then
+			quarantine_hits=1
+		fi
+		if [ "$quarantine_clean" == "0" ] && [ "$quar_clean" == "1" ]; then
+			quarantine_clean="1"
+		fi
+		if [ -f "files/internals/compat.conf" ]; then
+			source files/internals/compat.conf
+		fi
+		source $conftemp
+		echo "imported config options from $inspath.last/conf.maldet"
 	fi
-	if [ "$quarantine_clean" == "0" ] && [ "$quar_clean" == "1" ]; then
-		quarantine_clean="1"
+	$inspath/maldet --update 1
+	if [ "$monmode" == "1" ]; then
+		echo "detected active monitoring mode, restarted inotify watch with '-m users'"
+		$inspath/maldet -m users >> /dev/null 2>&1 &
 	fi
-	if [ -f "files/internals/compat.conf" ]; then
-		source files/internals/compat.conf
-	fi
-	source $conftemp
-	echo "imported config options from $inspath.last/conf.maldet"
-fi
-$inspath/maldet --update 1
-if [ "$monmode" == "1" ]; then
-	echo "detected active monitoring mode, restarted inotify watch with '-m users'"
-	$inspath/maldet -m users >> /dev/null 2>&1 &
 fi
 echo ""


### PR DESCRIPTION
* Reworked some code to avoid duplication of code.
* Make ClamAV code optional (Gentoo USE flag control).
* Only search for ClamAV path if not explicitly specified.  If
  explicitly specified, assume it to be accurate.
* Introduce ${prefix} variable to enable installing into staging area
  (required for package management).
* Allow for overriding inspath.  MISSING:  quite a number of files needs
  to be edited for this to work, for Gentoo ebuild I currently just sed
  all files replacing /usr/local with /opt - which actually negates the
  need for this option (ideally this option should make the required
  adjustments pre-install).