### PR TITLE
Fixed concerns with inotify monitoring

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1428,8 +1428,11 @@ monitor_cycle() {
 		fi
 		log_size=`$wc -l $inotify_log | awk '{print$1}'`
 		if [ "$log_size" -ge "$inotify_trim" ]; then
-			trim=1000
-			printf "%s\n" "$trim,${log_size}d" w | ed -s $inotify_log 2> /dev/null
+			trim=$(($log_size - 1000))
+			log_chars=`printf "%s\n" "1,${trim}p" | ed -s $inotify_log 2> /dev/null | wc -c`
+			tlog_new=$(( `cat $inspath/tmp/inotify` - $log_chars ))
+			echo $tlog_new > $inspath/tmp/inotify
+			printf "%s\n" "1,${trim}d" w | ed -s $inotify_log 2> /dev/null
 			eout "{mon} inotify log file trimmed"
 		fi
 		if [ "$inotify_cycle_runtime" -ge "$inotify_reloadtime" ] || [ -f "$inspath/reload_monitor" ]; then


### PR DESCRIPTION
This change should resolve the following concerns:

1) Instead of trimming off the start of /usr/local/maldetect/logs/inotify_log, we were trimming off the end

2) When /usr/local/maldetect/logs/inotify_log was trimmed, /usr/local/maldetect/tmp/inotify (generated by tlog) was not updated to reflect the new file size, thus tlog would start again from the beginning, and those first 999 lines would be processed over and over again. This is wasted processing power to re-scan these files over and over. (see [the current version of the file, line 1495](https://github.com/rfxn/linux-malware-detect/blob/c9cfe35fc88a6c7fa098b5642b4dacd08547312f/files/internals/functions#L1495) for specifics on where tlog is being called.)

3) Because tlog is only looking at the size of the log file, it was possible (though very unlikely) that there would be enough writes to the file to exceed the pre-trimmed file size, thus resulting in changes not being noticed or scanned