### PR TITLE
clamscan_max_filesize not set

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -847,6 +847,7 @@ clamselector() {
                 scan_max_filesize="${scan_max_filesize}c"
         else
                 scan_max_filesize="2048k"
+                clamscan_max_filesize="2592000"
         fi
 
         if [ "$scan_clamscan" == "1" ]; then


### PR DESCRIPTION
In an edge case where md5v2.dat is an empty file, not having this variable set
causes clamscan to fail to run