### PR TITLE
Fixed "-co" to work with spaces and commas

### DIFF
--- a/files/maldet
+++ b/files/maldet
@@ -114,7 +114,7 @@ else
 				tmpco=$tmpdir/config.cli
 				rm -f $tmpco
 				touch $tmpco
-				echo $1 | sed -e 's/--config-option //' -e 's/-co //' | tr -d ' ' | tr ',' '\n' > $tmpco
+				echo ,$1 | sed -e 's/-\(-config-option\|co\) //' -e 's/\(, *[a-z_]*=\)/\n\1\n/g' | sed -e '1d' -e 's/^\([^,].*\|.*[^=]\)$/"\1"/' | sed -e '$!N;s/\n//' -e 's/^, *//' > $tmpco
 				. $tmpco
 				rm -f $tmpco
 			;;


### PR DESCRIPTION
**Problem:** When maldet parses the "--config-option" argument, it does so with the following string of commands:

```
echo $1 | sed -e 's/--config-option //' -e 's/-co //' | tr -d ' ' | tr ',' '\n' > $tmpco
```

Because of this, config options that include spaces lose those spaces, and config options that include commas get broken up. Thus the following two legitimate config options do not work as intended:

```
scan_tmpdir_paths="/tmp /var/tmp /dev/shm"
inotify_docroot="public_html,public_ftp"
```

Instead they are transformed into the following:

```
scan_tmpdir_paths=/tmp/var/tmp/dev/shm
inotify_docroot=public_html
public_ftp
```

Getting around these oddities without changing the currently defined formatting for this command-line option is probably more complicated than it needs to be. The best way I could find to accomplish it was a string of piped sed commands. It's possible that this can be optimized further than I was able, but the change I've made is successful at allowing for spaces and commas in values.

```
echo ,$1 | sed -e 's/-\(-config-option\|co\) //' -e 's/\(, *[a-z_]*=\)/\n\1\n/g' | sed -e '1d' -e 's/^\([^,].*\|.*[^=]\)$/"\1"/' | sed -e '$!N;s/\n//' -e 's/^, *//' > $tmpco
```

I know that regular expressions are difficult to read at the best of times, so I'm going to explain each portion of this in probably more detail than is necessary in hopes of eliminating any confusion, and also so that if there's anything that I've overlooked here, it will be easy for my work to be modified to still achieve the desired end result while fitting other needs.

```
echo ,$1
```

We start by appending a comma to the beginning of the argument - this simplifies the process of recognizing the first variable name as a variable name later on. Because of this, all variable names will have a comma immediately before them and an equals sign immediately after them.

```
's/-\(-config-option\|co\) //'
```

The first sed pattern removes extra instances of "--config-option" or "-co" followed by a single space. It's similar to how it was done in the original, except that it is combined into one sed argument instead of two.

```
's/\(, *[a-z_]*=\)/\n\1\n/g'
```

This finds any instance within the string where we have a pattern of a comma (optionally followed by any number of spaces) followed by any number of characters that are lowercase letters or underscores, followed by an equals sign. Looking at the maldet configs, I'm not seeing any variables set within that include numbers or uppercase characters, so this should match any variable that the user might present us with. Because we put an extra comma at the beginning, it will not fail to match the first variable name that it was given.

It takes each of these patterns of comma, variable name, equals sign, and puts a newline character before and after it, thus separating the variables from the values that we're defining to them.

**Note**: The original process for parsing this argument had the following: `tr -d ' '`. I have to admit that I'm not sure of the entire scope of the issues that this was in place to solve.

My assumption has been that it was in place so that if instead of running the command only quoting the values like this: `maldet --config-option email_alert="0",scan_tmpdir_paths="/tmp /var/tmp /dev/shm",inotify_docroot=",public_html,public_ftp"` there were instances where people were quoting the whole thing, like this: `maldet --config-option "email_alert=0,scan_tmpdir_paths=/tmp /var/tmp /dev/shm,inotify_docroot=public_html,public_ftp"`. Quoting the whole thing would allow people to to try to separate variable/value pairs with commas followed by spaces instead of just commas.

Allowing the regex to also match a number of spaces here resolves that potential, and since the variable names will never begin with spaces, this is harmless.

```
'1d'
```

The previous operation left us starting out with a blank line. This removes that line.

```
's/^\([^,].*\|.*[^=]\)$/"\1"/'
```

For any of the lines that either do not start with a comma or end in an equals sign, this surrounds them with double quotes. This should fail to match the variable names and only match the values. While there is the potential for odd instances where a value might begin with a comma or end in an equals sign, it is EXTREMELY unlikely for a situation to arrise where both occur in the same value.

**Note**: We could use extended regular expressions here and instead have this be `'s/^([^,].*|.*[^=])$/"\1"/'`. It's a little bit prettier, but both are equally functional, so I don't see any need to do so.

**Another Note**: The above pattern will not match empty values, thus if we're trying to set `scan_tmpdir_paths=""`, the result at the end will be a line that reads `scan_tmpdir_paths=` instead of `scan_tmpdir_paths=""`. Not having the quotes is valid for setting an empty variable in bash, so it shouldn't be an issue, but if it **is**, there's no reason why we cannot throw an extra `-e 's/^$/""/'` before the pipe so that any empty lines are replaced with a pair of double quotes.

**A Third Note**: I cannot think of any reasons why double quotes or single quotes would be preferable here. I went with double quotes because that's what is used in conf.maldet.

```
'$!N;s/\n//'
```

This takes every pair of two lines and removes the new line character that's between them. It's one of those aspects of sed that I've never fully wrapped my head around, but there's an explanation for how it works here:

https://stackoverflow.com/questions/1513861/how-do-i-pair-every-two-lines-of-a-text-file-with-bash#comment1368415_1513918

```
's/^, *//'
```

Leading up to this pattern, all of the lines should begin with a comma (potentially followed by a number of spaces). This removes it so that the line will begin immediately with the variable name.

After all of this, we end up with lines that contain the variable followed by an equals sign, followed by a double quoted value.