### PR TITLE
Parse all arguments before launching jobs

### DIFF
--- a/files/maldet
+++ b/files/maldet
@@ -60,6 +60,33 @@ fi
 # prerun operations
 prerun
 
+check_operation() {
+	if [[ "$operation" == "$1" ]]; then
+		echo "You cannot use the flag \"$operation\" twice"
+		postrun
+	elif [[ -n "$operation" ]]; then
+		echo "You cannot use the flags \"$operation\" and \"$1\" simultaneously"
+		postrun
+	fi
+	operation="$1"
+}
+
+assign_args() {
+	firstarg=
+	secondarg=
+	if [[ "$1" == "--help" || "$2" == "--help" || "$1" == "-h" || "$2" == "-h" ]]; then
+		header
+		usage_long | more
+		postrun
+	fi
+	if [[ -n "$1" ]]; then
+		firstarg="$1"
+	fi
+	if [[ -n "$2" ]]; then
+		secondarg="$2"
+	fi
+}
+
 if [ -z "$1" ]; then
 	header
 	usage_short
@@ -128,11 +155,6 @@ else
 			-b|--background)
 				set_background=1
 			;;
-			-c|--checkout)
-				shift
-				header
-				checkout "$1"
-			;;
 			-x|--exclude-regex)
 				shift
 				if [ "$1" ]; then
@@ -151,164 +173,175 @@ else
 					web_proxy="$1"
 				fi
 			;;
-			--alert-daily|--monitor-report)
-				genalert digest
+			--alert-daily|--monitor-report|-k|--kill-monitor|-kill|-l|--log|-p|--purge)
+				check_operation "$1"
 			;;
-			-m|--monitor)
-				header
+			-m|--monitor|-c|--checkout|-f|--file-list|-a|--scan-all|-s|--restore|-q|--quarantine|-n|--clean)
+				check_operation "$1"
 				shift
-				if [ "$OSTYPE" == "FreeBSD" ]; then
-					eout "{mon} not currently supported under FreeBSD" 1
-				elif [ "$1" == "reload" ] || [ "$1" == "RELOAD" ]; then
-					eout "{mon} queued monitor for configuration reload" 1
-					touch $inspath/reload_monitor
-				else
-					svc=m
-					trap trap_exit 2
-					monitor_init "$1"
-				fi
+				assign_args "$1"
 			;;
-			-k|--kill-monitor|-kill)
-				header
-				if [ "$OSTYPE" == "FreeBSD" ]; then
-					eout "{mon} not currently supported under FreeBSD" 1
-				else
-					monitorpid=`pgrep -f inotify.paths.[0-9]+`
-					if [ -z "$monitorpid" ]; then
-						eout "{mon} could not find running inotifywait process, are we already dead?" 1
-					else
-						eout "{mon} sent kill to monitor service (pid: $monitorpid)" 1
-						monitor_kill
-					fi
-				fi
-			;;
-			-f|--file-list)
+			-r|--scan-recent|-e|--report)
+				check_operation "$1"
 				shift
-				if [ -z "$hscan" ]; then
-					header
-				fi
-				svc=f
-				trap trap_exit 2
-				file_list="$1"
-				if [ ! -f "$file_list" ]; then
-					eout "{scan} file does not exist ($1)" 1
-					exit 1
-					elif [ ! -s "$file_list" ]; then
-					eout "{scan} file list is empty ($1)" 1
-					exit 1
-				fi
-				if [ "$set_background" == "1" ]; then
-					eout "{scan} launching scan of $spath to background, see $maldet_log for progress" 1
-					scan "$spath" "$file_list" >> /dev/null 2>&1 &
-				else
-					scan "$spath" "$file_list"
+				assign_args "$1" "$2"
+				shift
+			;;
+			-d|--update-ver|--update-version)
+				check_operation "$1"
+				if [[ "$2" == "1" || "$2" == "--force" || "$2" == "--beta" ]]; then
+					shift
+					assign_args "$1"
 				fi
 			;;
-			-a|--scan-all)
-				shift
-				if [ -z "$hscan" ]; then
-					header
+			-u|--update|--update-sigs)
+				process_update=1
+				if [[ "$2" == "1" || "$2" == "--force" ]]; then
+					shift
+					updatearg="$2"
 				fi
-				svc=a
-				trap trap_exit 2
-				spath="$1"
-				hrspath="$1"
-				if [ "$spath" == "" ]; then
-					spath=/home
-				fi
-				if [ "$set_background" == "1" ]; then
-					eout "{scan} launching scan of $spath to background, see $maldet_log for progress" 1
-					scan "$spath" all >> /dev/null 2>&1 &
-				else
-					scan "$spath" all
-				fi
-			;;
-			-r|--scan-recent)
-				header
-				svc=r
-				trap trap_exit 2
-				shift
-				spath="$1"
-				shift
-				days="$1"
-				if [ -z "$spath" ]; then
-					eout "{scan} no path defined" 1
-					exit
-				fi
-				if [ -z "$days" ]; then
-					days=7
-				fi
-				if [ "$set_background" == "1" ]; then
-					eout "{scan} launching scan of $spath changes in last ${days}d to background, see $maldet_log for progress" 1
-					scan "$spath" "$days" >> /dev/null 2>&1 &
-				else
-					scan "$spath" "$days"
-				fi
-			;;
-			-l|--log)
-				header
-				view
-			;;
-			-e|--report)
-				header
-				shift
-				view_report "$1" "$2"
-			;;
-			-p|--purge)
-				header
-				purge
-			;;
-                        -d|--update-ver|--update-version)
-				shift
-                                if [ ! "$1" == "1" ]; then
-                                        header
-				fi
-				if [ "$1" == "--force" ]; then
-					lmdup_force=1
-                                elif [ "$1" == "--beta" ]; then
-					lmdup_beta=1
-				fi
-                                lmdup
-                        ;;
-                        -u|--update|--update-sigs)
-                                shift
-                                if [ ! "$1" == "1" ]; then
-                                        header
-				fi
-				if [ "$1" == "--force" ]; then
-					sigup_force=1
-                                fi
-                                sigup
-                        ;;
-			-s|--restore)
-				header
-				shift
-				if [ -f "$sessdir/session.hits.$1" ]; then
-					restore_hitlist "$1"
-				else
-					restore "$1"
-				fi
-			;;
-			-q|--quarantine)
-				header
-				shift
-				quar_hitlist "$1"
-			;;
-			-n|--clean)
-				header
-				shift
-				clean_hitlist "$1"
 			;;
 			-h|--help)
 				header
 				usage_long | more
+				postrun
 			;;
 			*)
-				header
-				usage_short
+				unknown_arg=1
 		esac
 		shift
 	done
+
+	# Update if requested
+	if [[ -n "$process_update" && -z "$unknown_arg" ]]; then
+		shift
+		if [ ! "$updatearg" == "1" ]; then
+			already_header=1
+			header
+		fi
+		if [ "$updatearg" == "--force" ]; then
+			sigup_force=1
+		fi
+		sigup
+	fi
+
+	# Perform the operation requested
+	if [[ "$operation" == "--alert-daily" || "$operation" == "--monitor-report" ]]; then
+		genalert digest
+	elif [[ "$operation" == "-f" || "$operation" == "--file-list" ]]; then
+		if [[ -z "$hscan" && -z "$already_header" ]]; then
+			header
+		fi
+		svc=f
+		trap trap_exit 2
+		file_list="$firstarg"
+		if [ ! -f "$file_list" ]; then
+			eout "{scan} file does not exist ($firstarg)" 1
+			exit 1
+		elif [ ! -s "$file_list" ]; then
+			eout "{scan} file list is empty ($firstarg)" 1
+			exit 1
+		fi
+		if [ "$set_background" == "1" ]; then
+			eout "{scan} launching scan of $spath to background, see $maldet_log for progress" 1
+			scan "$spath" "$file_list" >> /dev/null 2>&1 &
+		else
+			scan "$spath" "$file_list"
+		fi
+	elif [[ "$operation" == "-a" || "$operation" == "--scan-all" ]]; then
+		if [[ -z "$hscan" && -z "$already_header" ]]; then
+			header
+		fi
+		svc=a
+		trap trap_exit 2
+		spath="$firstarg"
+		hrspath="$firstarg"
+		if [ "$spath" == "" ]; then
+			spath=/home
+		fi
+		if [ "$set_background" == "1" ]; then
+			eout "{scan} launching scan of $spath to background, see $maldet_log for progress" 1
+			scan "$spath" all >> /dev/null 2>&1 &
+		else
+			scan "$spath" all
+		fi
+	elif [[ "$operation" == "-d" || "$operation" == "--update-ver" || "$operation" == "--update-version" ]]; then
+		if [[ "$firstarg" != "1" && -z "$already_header" ]]; then
+			header
+		fi
+		if [ "$firstarg" == "--force" ]; then
+			lmdup_force=1
+		elif [ "$firstarg" == "--beta" ]; then
+			lmdup_beta=1
+		fi
+		lmdup
+	else
+		if [[ -z "$already_header" ]]; then
+			header
+		fi
+		if [[ -n "$unknown_arg" || ( -z "$operation" && -n "$process_update" ) ]]; then
+			usage_short
+		elif [[ "$operation" == "-c" || "$operation" == "--checkout" ]]; then
+			checkout "$firstarg"
+		elif [[ "$operation" == "-m" || "$operation" == "--monitor" ]]; then
+			if [ "$OSTYPE" == "FreeBSD" ]; then
+				eout "{mon} not currently supported under FreeBSD" 1
+			elif [ "$firstarg" == "reload" ] || [ "$firstarg" == "RELOAD" ]; then
+				eout "{mon} queued monitor for configuration reload" 1
+				touch $inspath/reload_monitor
+			else
+				svc=m
+				trap trap_exit 2
+				monitor_init "$firstarg"
+			fi
+		elif [[ "$operation" == "-k" || "$operation" == "--kill-monitor" || "$operation" == "-kill" ]]; then
+			if [ "$OSTYPE" == "FreeBSD" ]; then
+				eout "{mon} not currently supported under FreeBSD" 1
+			else
+				monitorpid=`pgrep -f inotify.paths.[0-9]+`
+				if [ -z "$monitorpid" ]; then
+					eout "{mon} could not find running inotifywait process, are we already dead?" 1
+				else
+					eout "{mon} sent kill to monitor service (pid: $monitorpid)" 1
+					monitor_kill
+				fi
+			fi
+		elif [[ "$operation" == "-r" || "$operation" == "--scan-recent" ]]; then
+			svc=r
+			trap trap_exit 2
+			spath="$firstarg"
+			days="$secondarg"
+			if [ -z "$spath" ]; then
+				eout "{scan} no path defined" 1
+				exit
+			fi
+			if [ -z "$days" ]; then
+				days=7
+			fi
+			if [ "$set_background" == "1" ]; then
+				eout "{scan} launching scan of $spath changes in last ${days}d to background, see $maldet_log for progress" 1
+				scan "$spath" "$days" >> /dev/null 2>&1 &
+			else
+				scan "$spath" "$days"
+			fi
+		elif [[ "$operation" == "-l" || "$operation" == "--log" ]]; then
+			view
+		elif [[ "$operation" == "-e" || "$operation" == "--report" ]]; then
+			view_report "$firstarg" "$secondarg"
+		elif [[ "$operation" == "-p" || "$operation" == "--purge" ]]; then
+			purge
+		elif [[ "$operation" == "-s" || "$operation" == "--restore" ]]; then
+			if [ -f "$sessdir/session.hits.$firstarg" ]; then
+				restore_hitlist "$firstarg"
+			else
+				restore "$firstarg"
+			fi
+		elif [[ "$operation" == "-q" || "$operation" == "--quarantine" ]]; then
+			quar_hitlist "$firstarg"
+		elif [[ "$operation" == "-n" || "$operation" == "--clean" ]]; then
+			clean_hitlist "$firstarg"
+		fi
+	fi
 fi
 
 # import any remote configuration data


### PR DESCRIPTION
### Problem:

Maldet begins launching jobs before it finishes parsing the command line arguments.

This results in two potential issues: First, it's possible for Maldet to begin a process without having applied all of the options that the user intended. For example, this the command

```
maldet -a /home/user/public_html/ -b
```

does not start the job in the background as was intended, but instead in the foreground.

Another good example where it's common to want this functionality is with the "--help" flag: if a user is trying to put together the arguments that they want, but stumbles on syntax part way through, it's useful if they can just append "--help" to what they have so far, and get the output that they're looking for. Once they've read it, they can press the up arrow, hit backspace a few times, and continue on with putting arguments in palce. This command, however will not result in that behavior:

```
maldet -a --help
```

The second issue is that when background mode is specified, it's possible to launch multiple simultaneous background jobs:

```
maldet -b -a /home/user1/public_html/ -a /home/user2/public_html/ -a /home/user3/public_html/
```

This has the potential of easily overwhelming a smaller system.

### Caveat:

There are situations where processing the command line arguments in this manner can be beneficial. If for example, a user wants to run two different scans in succession, they can currently run the following:

```
maldet -a /home/user1/public_html/ -a /home/user2/public_html/
```

That being said the loss of this functionality is easy to work around for someone with even the most basic command line skills:

```
maldet -a /home/user1/public_html/; maldet -a /home/user2/public_html/
```

I am putting together these changes with the assumption that Ryan and other developers who have worked on this project have interpreted the above functionality as an occasionally pleasant accident rather than a fully blown feature. If I am incorrect in my assumption here, then... I guess these changes will be rejected. I'm okay with that.

### Proposed Solution:

The solution that I've implimented here separates out the process of parsing the command-line arguments from the process of actually performing operations. First we go through all of the command line arguments, then we react if any of them don't make sense, and finally we move forward with the operation that was specified.

In order to accomplish this with as few changes as possible to the existing code, I added two functions - one for determining what the specified operation was and erroring out if one had already been designated ([lines 63 through 72](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R63)), and one for capturing any arguments or flags that should follow the main argument we were looking for in the case statement, while also checking them to see if they are the user asking for help ([lines 74 through 88](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R74))

With these in place, the process of capturing the necessary data for many of the operations looked very much the same, with only some minor variations (as can be seen in [lines 176 through 196](https://github.com/sporks5000/linux-malware-detect/blob/parsearg/files/maldet#L176-L196)).

The process for "--update-sigs" was the only operation that I saw significant benefit for running in tandem with another operation. In [lines 197 through 202](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R197) I captured the relevant data from if it had been specified on the command line, and in [lines 216 through 226](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R216) I used the captured arguments and had it run as it did previously. This means that all of the following commands will successfully update the signatures **and then** scan a directory:

```
maldet -u -a /home/user/public_html
maldet -a /home/user/public_html -u
maldet -u --force -a /home/user/public_html
maldet -a /home/user/public_html -u --force
```

But that these commands will neither run a scan nor update the signatures, but only output the help text:

```
maldet -a --help /home/user/public_html -u --force
maldet -a /home/user/public_html --help -u --force
maldet -a /home/user/public_html -u --help --force
maldet -a /home/user/public_html -u --force --help
```

Many of the operations performed by Maldet output the header first thing by default. Because "--update-sigs" does so as well, I had to make sure that this did not occur twice. On [line 219](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R219) I set the "already_header" variable to indicate that the header had already been output, and on lines [232](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R232), [252](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R252), [269](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R269), and [279](https://github.com/rfxn/linux-malware-detect/compare/master...sporks5000:parsearg#diff-9acbdde66a0629e3aef2b91ad13bcca8R279), I used that variable to check whether or not the header should be displayed.

[Lines 229 through 277](https://github.com/sporks5000/linux-malware-detect/blob/parsearg/files/maldet#L229-L277) cover all of the Maldet operations that do not necessarily output the header first thing. The script checks against these first to see if we are performing any of them. If not, it outputs the header on [line 280](https://github.com/sporks5000/linux-malware-detect/blob/parsearg/files/maldet#L280). [Lines 282 through 343](https://github.com/sporks5000/linux-malware-detect/blob/parsearg/files/maldet#L282-L343) are all of the other potential Maldet operations that WOULD have output the header immediately.

It's not easy to tell from the git diffs, but for [lines 216 through 343](https://github.com/sporks5000/linux-malware-detect/blob/parsearg/files/maldet#L216-L343), I did my best to change the code here as little as possible. In addition to what I've described above, only the following changes were made:

* Changes to indentation
* Removed all instances of "shift", as these had been handled earlier on
* Replaced all instances of "$1" and "$2" with "$firstarg" and "$secondarg" (or "$updatearg")
* Removed calling the "header" function in instances where this had already been handled
* Order is changed to separate out operations with headers from operations without
* Use of "if/then" instead of "case"

### Conclusion:

I've written way too much, but I've had people give me changed code before without any explanation for the changes they made or what they were trying to accomplish, and I don't want anyone else to have to go through that particular hell because of me. Whether or not you choose to accept this pull request, I hope that at the very least you found what I was trying to accomplish here to be well explained and able to be understood.