### PR TITLE
Ability to disable cron scan via conf

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -66,7 +66,7 @@ fi
 # if we're running inotify monitoring, send daily hit summary
 if [ "$(ps -A --user root -o "cmd" | grep -E maldetect | grep -E inotifywait)" ]; then
         $inspath/maldet --monitor-report >> /dev/null 2>&1
-else
+elif [ $perform_daily_scan == "1" ]
 	if [ -d "/home/virtual" ] && [ -d "/usr/lib/opcenter" ]; then
 		# ensim
 	        $inspath/maldet -b -r /home/virtual/?/fst/var/www/html/,/home/virtual/?/fst/home/?/public_html/ $scan_days >> /dev/null 2>&1

--- a/files/conf.maldet
+++ b/files/conf.maldet
@@ -53,6 +53,11 @@ autoupdate_version_hashed="1"
 # with the daily cron execution.
 cron_prune_days="21"
 
+# This controls whether or not daily automatic scanning of standard web
+# directories is performed via cron.
+# [0 = disabled, 1 = enabled]
+perform_daily_scan="1"
+
 # When defined, the import_config_url option allows a configuration file to be
 # downloaded from a remote URL. The local conf.maldet and internals.conf are
 # parsed followed by the imported configuration file. As such, only variables


### PR DESCRIPTION
[Issue 260](https://github.com/rfxn/linux-malware-detect/issues/260) requests the ability to disable daily scans by setting a config option within the conf.maldet file. It seemed really easy to implement, and I had a few spare minutes, so I didn't see any reason not to.

I do not BELIEVE that any changes are necessary to install.sh or compat.conf (or various other files called or referenced during the update process) in order to get this in place, but if there's something I've overlooked, point me in the right direction, and I'll be glad to make the necessary changes and resubmit.