### PR TITLE
Further changes to "-co"

### DIFF
--- a/files/maldet
+++ b/files/maldet
@@ -141,9 +141,12 @@ else
 				tmpco=$tmpdir/config.cli
 				rm -f $tmpco
 				touch $tmpco
-				echo ,$1 | sed -e 's/-\(-config-option\|co\) //' -e 's/\(, *[a-z_]*=\)/\n\1\n/g' | sed -e '1d' -e 's/^\([^,].*\|.*[^=]\)$/"\1"/' | sed -e '$!N;s/\n//' -e 's/^, *//' > $tmpco
+				echo ,$1 | sed -e 's/-\(-config-option\|co\) //' -e 's/\(, *[a-zA-Z0-9_][a-zA-Z0-9_]*=\)/\n\1\n/g' | sed -e '1d' -e 's/^\([^,].*\|.*[^=]\)$/"\1"/' | sed -e '$!N;s/\n//' -e 's/^, *//' | grep -v "^ *compatcnf" > $tmpco
 				. $tmpco
 				rm -f $tmpco
+				if [ -f "$compatcnf" ]; then
+					source $compatcnf
+				fi
 			;;
 			-qd)
 				shift


### PR DESCRIPTION
Three key changes here:

1. `'s/\(, *[a-z_]*=\)/\n\1\n/g'` is changed to `'s/\(, *[a-zA-Z0-9_][a-zA-Z0-9_]*=\)/\n\1\n/g'`. This accounts for all variable names with capital letters and numbers. **conf.maldet** doesn't have them, but **internals.conf** and **/etc/sysconfig/maldet** have a few, and while the help text indicates that "-co" is just for **conf.maldet**, technically there has never been anything stopping it from being used for those other configurations previously. It also requires there to be at least one character before the equals sign in order to match the regex, (having zero characters shouldn't be a thing that would ever happen if the argument is used correctly, but better to be safe than sorry)

2. After writing to and reading from the file that this creates, `source $compatcnf` is run again in case any of the old variable names had been used. (I only today realized that not having this was causing some unexpectedness in a script that I had originally written back in 2012 and thankfully had not been used much since then. But if it could cause weirdness for one person, there are probably others as well.)

3. Prevents the variable "compatcnf" from being able to be set by "-co". Because allowing the user to just tell Maldet to source some random script would probably not be a best practice.