### PR TITLE
Update view_report()

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -441,6 +441,7 @@ usage $0 [ OPTION ]
        e.g: maldet --report list
        e.g: maldet --report 050910-1534.21135
        e.g: maldet --report SCANID user@domain.com
+       e.g: maldet --report newest user@domain.com
 
     -s, --restore FILE|SCANID
        Restore file from quarantine queue to orginal path or restore all items from
@@ -643,7 +644,9 @@ clean_hitlist() {
 }
 
 view_report() {
+	# $1 is first arg passed from command line ex. $ maldet --report $1 $2
 	rid="$1"
+	# $ maldet --report list
 	if [ "$rid" == "list" ]; then
 		tmpf="$tmpdir/.areps$$"
 		for file in `ls $sessdir/session.[0-9]* 2> /dev/null`; do
@@ -674,36 +677,44 @@ view_report() {
 			rm -f $tmpf 2> /dev/null
 			exit 0
 		else
-			echo  "error no report data found"
+			eout  "{list} unable to find report data for list, check \$sessdir"
 			exit 1
 		fi
 	fi
-	if [ -f "$sessdir/session.$rid" ] && [ ! -z "$(echo $2 | grep '\@')" ]; then
-	    if [ -f "$mail" ]; then
-		    cat $sessdir/session.$rid | $mail -s "$email_subj" "$2"
-		elif [ -f "$sendmail" ]; then
-		    if ! grep -q "SUBJECT: " "$sessdir/session.$rid"; then
-		        echo -e "SUBJECT: $email_subj\n$(cat $sessdir/session.$rid)" > $sessdir/session.$rid
-		    fi
-		    cat $sessdir/session.$rid | $sendmail -t "$2"
-		else
-		    eout "{scan} no \$mail or \$sendmail binaries found, e-mail alerts disabled."
-		    exit
-		fi
-
-        eout "{report} report ID $rid sent to $2" 1
-		exit
-	fi
-	if [ "$rid" == "" ] && [ -f "$sessdir/session.last" ]; then
+	# If no SCANID is provided or "recent" then set $rid to most recent. 
+	# $ maldet --report "" or $maldet --report newest
+	if { [ "$rid" == "" ] || [ "$rid" == "newest" ]; } && [ -f "$sessdir/session.last" ]; then
 		rid=`cat $sessdir/session.last`
-		$EDITOR $sessdir/session.$rid
-	elif [ -f "$sessdir/session.$rid" ]; then
-		$EDITOR $sessdir/session.$rid
+	fi
+	# make sure report exists
+	if [ -f "$sessdir/session.$rid" ]; then
+		# if email is provided then send the report and exit
+		if [ ! -z "$(echo $2 | grep '\@')" ]; then
+			if [ -f "$mail" ]; then
+				cat $sessdir/session.$rid | $mail -s "$email_subj" "$2"
+			elif [ -f "$sendmail" ]; then
+				if ! grep -q "SUBJECT: " "$sessdir/session.$rid"; then
+					echo -e "SUBJECT: $email_subj\n$(cat $sessdir/session.$rid)" > $sessdir/session.$rid
+				fi
+				cat $sessdir/session.$rid | $sendmail -t "$2"
+			else
+				# eout is an internal function to log to maldet_log and echo
+				eout "{scan} no \$mail or \$sendmail binaries found, e-mail alerts disabled."
+				exit
+			fi
+			eout "{report} report ID $rid sent to $2" 1
+			exit        
+		# no email is provided so show report and exit
+		else
+			printf '%b\n' "$(cat $sessdir/session.$rid)"
+			exit
+		fi
+	# can't find requested report so log & echo error
 	else
-		echo "{report} no report found, aborting."
+		eout "{report} unable to find report session.\$rid, aborting."
 		exit
 	fi
-}
+}    
 
 view() {
 	echo "Viewing last 50 lines from $maldet_log:"


### PR DESCRIPTION
Modified view_report() with following changes:
* added option 'newest' as alias to --report and --report "" to allow $ maldet --report newest user@domain.com
* properly email most recent report when using $ maldet --report newest user@domain.com or $ maldet --report "" user@domain.com
* change from unnecessarily using editor to view reports, instead simply print to terminal
* improved logging

This was to address long standing issues discussed here: https://serverfault.com/questions/805158/how-to-get-an-email-report-of-whatever-the-most-recent-maldet-scan-is