### PR TITLE
fix: view reports function must be a read-only feature

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -133,15 +133,6 @@ prerun() {
 		$sed -i -e '/^$/d' $ignore_paths $ignore_sigs $ignore_inotify $ignore_file_ext
 	fi
 
-	if [ -z "$EDITOR" ]; then
-		defedit=`which nano 2> /dev/null`
-		if [ -z "$defedit" ]; then
-			EDITOR=vi
-		else
-			EDITOR=nano
-		fi
-	fi
-
 	if [ ! "$scan_cpunice" ]; then
 		scan_cpunice=19
 	fi
@@ -696,9 +687,9 @@ view_report() {
 	fi
 	if [ "$rid" == "" ] && [ -f "$sessdir/session.last" ]; then
 		rid=`cat $sessdir/session.last`
-		$EDITOR $sessdir/session.$rid
+		cat $sessdir/session.$rid
 	elif [ -f "$sessdir/session.$rid" ]; then
-		$EDITOR $sessdir/session.$rid
+		cat $sessdir/session.$rid
 	else
 		echo "{report} no report found, aborting."
 		exit


### PR DESCRIPTION
Reports should be not editable exaclty as like as they were "logs".
They just can be read, but not written.

It's not coherent that maldet launch an editor in order to just view them.
Instead the report should be just printed to screen.
This allow also to read reports from CLI and pipe them to other scripts.

- Removed editors and forced to used simply "cat"