### PR TITLE
[Change] add new flag: -D|--dump-report

### DIFF
--- a/README
+++ b/README
@@ -276,6 +276,11 @@ option gives a detailed summary of usage options:
        e.g: maldet --report 050910-1534.21135
        e.g: maldet --report SCANID user@domain.com
 
+    -D, --dump-report SCANID
+       Similar to -e/--report except dumps the report to stdout instead.
+       e.g: maldet --dump-report
+       e.g: maldet --dump-report 050910-1534.21135
+
     -s, --restore FILE|SCANID
        Restore file from quarantine queue to orginal path or restore all items from
        a specific SCANID

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -696,13 +696,29 @@ view_report() {
 	fi
 	if [ "$rid" == "" ] && [ -f "$sessdir/session.last" ]; then
 		rid=`cat $sessdir/session.last`
+		if [ "$2" == "dump" ]; then
+			cat $sessdir/session.$rid
+			exit
+		fi
 		$EDITOR $sessdir/session.$rid
 	elif [ -f "$sessdir/session.$rid" ]; then
+		if [ "$2" == "dump" ]; then
+			cat $sessdir/session.$rid
+			exit
+		fi
 		$EDITOR $sessdir/session.$rid
 	else
 		echo "{report} no report found, aborting."
 		exit
 	fi
+}
+
+dump_report() {
+	rid="$1"
+	if [ rid == "" ]; then
+		rid=`cat sessdir/session.last`
+	fi
+	view_report $rid dump
 }
 
 view() {

--- a/files/maldet
+++ b/files/maldet
@@ -257,6 +257,11 @@ else
 				shift
 				view_report "$1" "$2"
 			;;
+			-E|--dump-report)
+				header
+				shift
+				dump_report "$1"
+			;;
 			-p|--purge)
 				header
 				purge

--- a/files/maldet.1
+++ b/files/maldet.1
@@ -6,7 +6,7 @@ maldet \- Linux Malware Detect
 .PP
 maldet [\-h|\-\-help] [\-a|\-\-scan\-all PATH] [\-r|\-\-scan\-recent PATH DAYS] [\-f|\-\-file\-list PATH]
 [\-i|\-\-include\-regex] [\-x|\-\-exclude\-regex] [\-b|\-\-background] [\-m|\-\-monitor] [\-k|\-\-kill\-monitor]
-[\-c|\-\-checkout] [\-q|\-\-quarantine] [\-s|\-\-restore] [\-n|\-\-clean] [\-l|\-\-log] [\-e|\-\-report]
+[\-c|\-\-checkout] [\-q|\-\-quarantine] [\-s|\-\-restore] [\-n|\-\-clean] [\-l|\-\-log] [\-e|\-\-report] [\-E|\-\-dump\-report]
 [\-u|\-\-update\-sigs]
 .SH DESCRIPTION
 Linux Malware Detect is a malware scanner for Linux released under the GNU GPLv2 license, that is designed around the threats faced in shared hosted environments. It uses threat data from network edge intrusion detection systems to extract malware that is actively being used in attacks and generates signatures for detection. In addition, threat data is also derived from user submissions with the LMD checkout feature and from malware community resources. The signatures that LMD uses are MD5 file hashes and HEX pattern matches, they are also easily exported to any number of detection tools such as ClamAV.
@@ -186,6 +186,12 @@ e.g: maldet \fB\-\-report\fR
 e.g: maldet \fB\-\-report\fR list
 e.g: maldet \fB\-\-report\fR 050910\-1534.21135
 e.g: maldet \fB\-\-report\fR SCANID user@domain.com
+.HP
+\fB\-e\fR, \fB\-\-dump-report\fR SCANID
+.IP
+Similar to \-\-report but dumps the report to stdout instead.
+e.g: maldet \fB\-\-dump\-report\fR
+e.g: maldet \fB\-\-dump\-report\fR 050910\-1534.21135
 .HP
 \fB\-s\fR, \fB\-\-restore\fR FILE|SCANID
 .IP


### PR DESCRIPTION
This dumps the report to stdout instead of trying to open an editor. This makes it possible to extract reports in unattended contexts/scripting.

This addresses https://github.com/rfxn/linux-malware-detect/issues/290#issuecomment-622377633 