### PR TITLE
Remote clamd

### DIFF
--- a/files/conf.maldet
+++ b/files/conf.maldet
@@ -299,3 +299,21 @@ inotify_verbose="0"
 # [ string length in characters, default = 150000 ]
 string_length_scan="0"		# [ 0 = disabled, 1 = enabled ]
 string_length="150000"		# [ max string length ]
+
+# Remote clamd support
+# If you're running a dedicated clamd server, you can instruct clamdscan to use
+# it instead of the local daemon (which doesn't even need to run). To use
+# this you need to create a 'clamd.remote.conf' with:
+#
+# TCPSocket3310
+# TCPAddr clamd.example.com
+#
+# To instruct maldetect to use that config, enter the path to that file:
+remote_clamd="/etc/clamd.d/clamd.remote.conf"
+
+# If remote clamd doesn't respond properly, how many times should we retry
+# the same file
+max_retry="5"
+
+# How many seconds to sleep between retrys
+retry_sleep="3"

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -911,7 +911,11 @@ clamselector() {
 
                 isclamd=`pgrep -x clamd 2> /dev/null`
                 isclamd_root=`pgrep -x -u root clamd 2> /dev/null`
-                if [ "$isclamd" ] && [ "$isclamd_root" ]; then
+                if [ "$remote_clamd" ]; then
+                       clamd=1
+                       clambin="clamdscan"
+                        clamopts="--fdpass -c /etc/clamd.d/clamd.remote.conf"
+                elif [ "$isclamd" ] && [ "$isclamd_root" ]; then
                         clamd=1
                         clambin="clamdscan"
                         clamopts="$clamdscan_extraopts"
@@ -938,7 +942,20 @@ clamselector() {
                 fi
                 if [ "$clamd" ] && [ "$scan_clamscan" == "1" ]; then
                         ## test clamdscan for errors as not all 'running' instances of clamd are indicative of working setup
-                        clamd_test=`$clamscan --fdpass --quiet --no-summary /etc/passwd 2> /dev/null || echo $?`
+                        if [ "$remote_clamd" ]; then
+                                try=0
+                                while [ $try -le $max_retry ]; do
+                                        clamd_test=`$clamscan $clamopts --fdpass --quiet --no-summary /etc/passwd 2> /dev/null || echo $?`
+                                        if [ "$clamd_test" = "2" ]; then
+                                                ((try++))
+                                                sleep $retry_sleep
+                                        else
+                                                break
+                                        fi
+                                done
+                        else
+                                clamd_test=`$clamscan --fdpass --quiet --no-summary /etc/passwd 2> /dev/null || echo $?`
+                        fi
                         if [ ! -z "$clamd_test" ]; then
                                 clamd=0
                                 clambin="clamscan"
@@ -1169,8 +1186,23 @@ scan() {
 		echo "$(date +"%b %d %Y %H:%M:%S") $(hostname -s) clamscan start"  >> $clamscan_log
 		clamscan_results="$tmpdir/.clamscan.$$"
 		echo "$(date +"%b %d %Y %H:%M:%S") $(hostname -s) executed: $nice_command $clamscan $clamopts --infected --no-summary -f $find_results" >> $clamscan_log
-		$nice_command $clamscan $clamopts --infected --no-summary -f $find_results > $clamscan_results 2>> $clamscan_log
-		clamscan_return=$?
+                if [ "$remote_clamd" ]; then
+                        try=0
+                        while [ $try -le $max_retry ]; do
+                                $nice_command $clamscan $clamopts --infected --no-summary -f $find_results > $clamscan_results 2>> $clamscan_log
+                                clamscan_return=$?
+                                if [ "$clamscan_return" == "2" ]; then
+                                        ((try++))
+                                        echo "$(date +"%b %d %H:%M:%S") $(hostname -s) remote clamd error - retrying in $retry_sleep seconds ($try)"
+                                        sleep $retry_sleep
+                                else
+                                        break
+                                fi
+                        done
+                else
+                        $nice_command $clamscan $clamopts --infected --no-summary -f $find_results > $clamscan_results 2>> $clamscan_log
+                        clamscan_return=$?
+                fi
 		if [ "$clamscan_return" == "2" ]; then
 			if [ "$quarantine_on_error" == "0" ] || [ -z "$quarantine_on_error" ]; then
 				quarantine_hits=0
@@ -1588,14 +1620,47 @@ monitor_cycle() {
 		exit
 }
 
+cleanup_scanlist() {
+        # Checks for files that are already gone (temporary files, cache
+        # files, ...) and removes them from $monitor_scanlist, so we don't
+        # get errors and too many retries
+        TMP_FILE=$(mktemp -p /var/lib/maldetect/tmp)
+        lbreakifs set
+        for FILE in $(cat $monitor_scanlist); do
+                if [ -f "$FILE" ]; then
+                        echo "$FILE" >> $TMP_FILE
+                fi
+        done
+        lbreakifs unset
+        mv $TMP_FILE $monitor_scanlist
+}
+ 
+
 monitor_check() {
                 monitor_scanlist="$tmpdir/.monitor.scan.${RANDOM}${RANDOM}"
 		touch $monitor_scanlist ; chmod 600 $monitor_scanlist
-		$tlog $inotify_log inotify | awk -F"CREATE|MODIFY|MOVED_FROM|MOVED_TO" '{print $1}' | grep -E -v '/.. ' | sort | uniq | sed 's/.{1}$//' > $monitor_scanlist
+                $tlog $inotify_log inotify | grep -E " CREATE| MODIFY| MOVED_TO" | awk -F" CREATE| MODIFY| MOVED_TO" '{print $1}' | sort -u | grep -vf $ignore_paths> $monitor_scanlist
 		if [ "$scan_clamscan" == "1" ]; then
 	                clamscan_results="$tmpdir/.clamscan.result.${RANDOM}${RANDOM}"
 			touch $clamscan_results ; chmod 600 $clamscan_results
 	                $nice_command $clamscan $clamopts --infected --no-summary -f $monitor_scanlist > $clamscan_results 2>> $clamscan_log || clamscan_return=$?
+                        if [ "$remote_clamd" ]; then
+                                try=0
+                                while [ $try -le $max_retry ]; do
+                                        cleanup_scanlist $monitor_scanlist
+                                        $nice_command $clamscan $clamopts --infected --no-summary -f $monitor_scanlist > $clamscan_results 2>> $clamscan_log
+                                        clamscan_return=$?
+                                        if [ "$clamscan_return" == "2" ]; then
+                                                ((try++))
+                                                echo "$(date +"%b %d %H:%M:%S") $(hostname -s) remote clamd error - retrying in $retry_sleep seconds ($try)" >> $clamscan_log
+                                                sleep $retry_sleep
+                                        else
+                                                break
+                                        fi
+                                done
+                        else
+                                $nice_command $clamscan $clamopts --infected --no-summary -f $monitor_scanlist > $clamscan_results 2>> $clamscan_log || clamscan_return=$?
+                        fi
 			if [ "$inotify_verbose" == "1" ]; then
 				for file in `cat $monitor_scanlist | tr ' ' '%'`; do
 					file=`echo $file | tr '%' ' '`

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -914,7 +914,7 @@ clamselector() {
                 if [ "$remote_clamd" ]; then
                        clamd=1
                        clambin="clamdscan"
-                        clamopts="--fdpass -c /etc/clamd.d/clamd.remote.conf"
+                        clamopts="--fdpass -c $remote_clamd"
                 elif [ "$isclamd" ] && [ "$isclamd_root" ]; then
                         clamd=1
                         clambin="clamdscan"


### PR DESCRIPTION
Because I run Linux Malware Detect (LMD) on several machines and clamd uses a lot of memory these days, I wanted to use remote clamd. Initially, I just used `clamdscan_extraopts=/etc/clamd.d/clamd.remote.conf` in my configuration, but for some reason that only worked for a couple of minutes - at some point, LMD started calling clamdscan without that option...

To address this, I:

1. made up 3 new configuration options in config file:

- `remote_clamd="/etc/clamd.d/clamd.remote.conf"` - this is name of the file that clamdscan uses and should contain the address and port of remote clamd:

```
TCPSocket3310
TCPAddr clamd.example.com
```

`$remote_clamd` is later used as the config file for clamdscan (`clamdscan -c $remote_clamd`).

Because temporary errors are more likely with a remote clamd, I also added a retry loop, which uses these config file options:

- `max_retry="5"` - how many times to retry
- `retry_sleep="3"` - waiting time in seconds between retries

2. modified `clamselector()` function to check if `remote_clamd` is set - if it is, it sets:

```
clamd=1
clambin="clamdscan"
clamopts="--fdpass -c /etc/clamd.d/clamd.remote.conf"
```

Clamd doesn't need to run on the local machine (the one running Linux Malware Detect).

I also changed the 'test clamdscan' code, so that it retries the test in case of a clamdscan error.

3. modified the `scan()` function and added a retry loop in case of a clamdscan error

4. added a new function `cleanup_scanlist()`, which takes the $monitor_scanlist and filters out the files that no longer exist (temporary files, ...) - without this, the 'retry' code would keep retrying the scan for files, that are long gone

5. modified `monitor_check()` function and added a retry loop while also implementing the `cleanup_scanlist()' to avoid unnecessary retries

6. in `monitor_check()` I also modified the inotify log filter:
- to better handle filenames with spaces (original code didn't work for filenames where 3rd character was a space (`my file` would not be listed in $monitor_scanlist)
- to also use `$ignore_paths`
- removed 'MOVED_FROM' (if the file is moved from somewhere, it can't be scanned in that original location anyway)