### PR TITLE
Add quotes around restore file paths.

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -567,14 +567,14 @@ restore() {
                 chmod $file_mode "$quardir/$file" >> /dev/null 2>&1
                 mv -f "$quardir/$file" "$file_path"
 		touch -m --date=@${file_mtime} "$file_path"
-                eout "{restore} quarantined file $file restored to $file_path" 1
+                eout "{restore} quarantined file '$file' restored to '$file_path'" 1
         elif [ -f "$file" ] && [ -f "${file}.info" ]; then
 		quar_get_filestat "${file}.info"
                 chown ${file_owner}.${file_group} "$file" >> /dev/null 2>&1
                 chmod $file_mode "$file" >> /dev/null 2>&1
                 mv -f "$file" "$file_path"
 		touch -m --date=@${file_mtime} "$file_path"
-                eout "{restore} quarantined file $file restored to $file_path" 1
+                eout "{restore} quarantined file '$file' restored to '$file_path'" 1
         else
                 eout "{restore} invalid file or could not be found" 1
         fi


### PR DESCRIPTION
The log for quarantine has quotes around the file path which helps with log file parsing, however the restore log does not have quotes which makes it difficult to parse the file names from the log. Adding quotes would make it match the logging for quarantines and easier to parse the file paths.