### PR TITLE
Add option to allow disabling log truncating of maldet log.

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -180,10 +180,12 @@ eout() {
 	if [ ! -f "$maldet_log" ]; then
 		touch $maldet_log
 	fi
-	log_size=`$wc -l $maldet_log | awk '{print$1}'`
-	if [ "$log_size" -ge "20000" ]; then
-		trim=1000
-		printf "%s\n" "$trim,${log_size}d" w | ed -s $maldet_log 2> /dev/null
+	if [ "$maldet_log_truncate" == "1" ]; then
+		log_size=`$wc -l $maldet_log | awk '{print$1}'`
+		if [ "$log_size" -ge "20000" ]; then
+			trim=1000
+			printf "%s\n" "$trim,${log_size}d" w | ed -s $maldet_log 2> /dev/null
+		fi
 	fi
 	if [ ! "$msg" == "" ]; then
 		echo "$(date +"%b %d %Y %H:%M:%S") $(hostname -s) $appn($$): $msg" >> $maldet_log

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -17,6 +17,7 @@ cnffile="conf.maldet"
 cnf="$confpath/$cnffile"
 varlibpath="$inspath"
 maldet_log="$logdir/event_log"
+maldet_log_truncate=1
 clamscan_log="$logdir/clamscan_log"
 datestamp=`date +"%y%m%d-%H%M"`
 utime=`date +"%s"`


### PR DESCRIPTION
We are looking to use logrotate to manage the life cycle of the maldet log rather than having maldet auto truncate the log when its larger than 20,000 lines long. This commit adds the option to enable the truncating with the default set to enabled which will allow override via the conf.maldet file.