### PR TITLE
Control panel user alerts

### DIFF
--- a/files/conf.maldet
+++ b/files/conf.maldet
@@ -25,6 +25,24 @@ email_addr="you@domain.com"
 # [0 = disabled, 1 = enabled]
 email_ignore_clean="1"
 
+# Enable user alerts for specific web hosting control panels. If hits are detected,
+# attempt to determine the web hosting control in use, if any. If a control
+# panel is detected, determine the user contact information from the panel's
+# toolset and send an email summary of the detected hits to that user.
+# The list of hits will be limited to files owned by the panel user/account in question.
+# Disabling alerts globally with email_alert will also disable this function.
+email_panel_user_alerts="0"
+
+# The from header that will be set on alerts to control panel users. This should
+# be set by any web hosts that will be supporting the control panel users/accounts 
+# on this server.
+email_panel_from="you@example.com"
+
+# The reply-to header that will be set on alerts to control panel users. This should
+# be set by any web hosts that will be supporting the control panel users/accounts 
+# on this server.
+email_panel_replyto="you@example.com"
+
 # Enable or disable slack alerts, this will upload the scan report as a file
 # into one or more slack channels
 # [0 = disabled, 1 = enabled]

--- a/files/conf.maldet
+++ b/files/conf.maldet
@@ -43,6 +43,9 @@ email_panel_from="you@example.com"
 # on this server.
 email_panel_replyto="you@example.com"
 
+# The subject that will be used on alerts to control panel account contacts
+email_panel_alert_subj="maldet alert from $(hostname)"
+
 # Enable or disable slack alerts, this will upload the scan report as a file
 # into one or more slack channels
 # [0 = disabled, 1 = enabled]

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1370,7 +1370,6 @@ scan() {
 			genalert file $nsess
 		fi
 		if [ "$email_panel_user_alerts" == "1" ]; then
-			eout "{alert} Panel alerts" 1
 			genalert panel $nsess
 		fi
 	fi

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1372,6 +1372,8 @@ scan() {
 			genalert file $nsess
 		elif [ "$email_ignore_clean" == "0" ]; then
 			genalert file $nsess
+		elif [ "$email_panel_user_alerts" == "1" ]; then
+			genalert panel $nsess
 		fi
 	fi
 	mv $scan_session $nsess_hits

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -273,7 +273,6 @@ detect_control_panel() {
 get_panel_contacts() {
 	panel="$1"
 	user="$2"
-	contact_emails=""
 	case "$panel" in
 		"cpanel")
 			if [ -f /var/cpanel/users/${user} ]; then
@@ -281,15 +280,12 @@ get_panel_contacts() {
 			else
 				contact_emails=$(cpapi2 --user=herpaderpadoo --output=xml CustInfo contactemails | grep -o 'value>.*</value' | sed -r 's,(</)?value>?,,g;/^$/d' | tr '\n' ',' | sed 's/,$//')
 			fi
-			break
 		;;
 		"interworx")
-			master_domain=$(/usr/local/interworx/bin/listaccounts.pex | grep "${user}" | awk "{print $2}")
-			contact_emails=$(/usr/bin/siteworx -un --login_domain ${master_domain} -c Users -a listUsers -o yaml | awk '/email:/{print $2}' | tr '\n' ',' | sed 's/,$//')
-			break
+			master_domain=$(/usr/local/interworx/bin/listaccounts.pex | grep "${user}" | awk '{print $2}')
+			contact_emails=$(/usr/bin/siteworx -un --login_domain ${master_domain} -c Users -a listUsers -o yaml | awk '/email:/{print $2}' | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /')
 		;;
 	esac
-    echo $contact_emails
 }
 
 get_remote_file() {
@@ -1372,7 +1368,9 @@ scan() {
 			genalert file $nsess
 		elif [ "$email_ignore_clean" == "0" ]; then
 			genalert file $nsess
-		elif [ "$email_panel_user_alerts" == "1" ]; then
+		fi
+		if [ "$email_panel_user_alerts" == "1" ]; then
+			eout "{alert} Panel alerts" 1
 			genalert panel $nsess
 		fi
 	fi
@@ -1524,6 +1522,7 @@ genalert() {
 				fi
 			fi
         elif [ "$type" == "panel" ] && [ -f "$file" ]; then 
+	    eout "{panel} Detecting control panel and sending alerts..." 1
             # Sort malware hits from $file and map the detected files to their system user owner
             file_hits=$(awk '/FILE HIT LIST:/{flag=1;next}/^=======/{flag=0}flag{print $3}' $file)
             for hit in $file_hits; do
@@ -1552,9 +1551,10 @@ genalert() {
                 eout "{panel} Failed to set control panel. Will not send alerts to control panel account contacts." 1
             else 
                 eout "{panel} Detected control panel $control_panel. Will send alerts to control panel account contacts." 1
-                user_list=$(awk '{print $1}' $tmpdir/.panel_alert.hits)
+                user_list=$(awk '{print $1}' $tmpdir/.panel_alert.hits | sort | uniq)
                 for sys_user in $user_list; do
-                    contact_emails=$(get_panel_contacts $control_panel $sys_user)
+		    contact_emails=""
+                    get_panel_contacts $control_panel $sys_user
 
                     grep "^$sys_user " $tmpdir/.panel_alert.hits | awk '{print $3}' > $tmpdir/.${sys_user}.hits
                     user_tot_hits=$($wc -l $tmpdir/.${sys_user}.hits | awk '{print$1}')
@@ -1564,24 +1564,20 @@ genalert() {
                     fi   
 
                     tmpf=$tmpdir/.${sys_user}.alert
-                    echo "TO: $contact_emails" > $tmpf
-                    echo "FROM: $email_panel_from" >> $tmpf
-                    echo "REPLY-TO: $email_panel_replyto" >> $tmpf
-                    . $email_panel_alert_etpl
 
-                    if [ -f "$mail" ]; then 
-                        if ! grep -q "SUBJECT: " "$tmpf"; then 
-                            cat $tmpf | $mail -s "$email_subj" $email_addr
-                        else 
-                            cat $tmpf | $mail $email_addr
-                        fi   
-                    elif [ -f "$sendmail" ]; then 
-                        if ! grep -q "SUBJECT: " "$tmpf"; then 
-                            echo -e "SUBJECT: $email_subj\n$(cat $file)" > $tmpf
-                        fi   
-                        cat $tmpf | $sendmail -t $email_addr
+                    if [ -f "$sendmail" ]; then 
+			echo "TO: $contact_emails" > $tmpf
+                        echo "FROM: $email_panel_from" >> $tmpf
+                        echo "REPLY-TO: $email_panel_replyto" >> $tmpf
+		        echo -e "SUBJECT: $email_panel_alert_subj\n" >> $tmpf
+                        . $email_panel_alert_etpl
+
+                        cat $tmpf | $sendmail -t
+                    elif [ -f "$mail" ] && [ "$control_panel" == "cpanel" ]; then 
+                        . $email_panel_alert_etpl
+                    	cat $tmpf | $mail -r $email_panel_from -s $email_panel_alert_subj $contact_emails
                     else 
-                        eout "{scan} no \$mail or \$sendmail binaries found, e-mail alerts disabled."
+                        eout "{panel} No compatible \$sendmail or \$mail binaries found, control panel account alerts disabled."
                     fi   
                 done 
             fi   

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -227,6 +227,71 @@ clean_exit() {
 	rm -f $clamscan_results $find_results $list $runtime_hdb $runtime_hexstrings $runtime_ndb $scan_session $tmpdir/.find_killed.$scanid $tmpdir/.tmp* $tmpdir/.tmpf* $tmpf 0 2> /dev/null
 }
 
+detect_control_panel() {
+	if [[ -d /usr/local/interworx ]]; then
+		iworx_db_ps=$(ps -u iworx | grep iworx-db)
+		iworx_web_ps=$(ps -u iworx-web | grep iworx-web)
+		pex_script=$(readlink -e /usr/local/interworx/bin/listaccounts.pex)
+		siteworx=$(which siteworx)
+
+		# Check that Iworx services are running
+		if [[ -z "$iworx_db_ps" || -z "$iworx_web_ps" ]]; then
+			control_panel="error"
+			eout "{panel} Interworx found, but not running. Panel user alerts will not be sent."
+		# Verify pex script exists and is executable
+		elif ! [[ -x "$pex_script" ]]; then
+			control_panel="error"
+			eout "{panel} Interworx found, but scripts are missing or not executable. Panel user alerts will not be sent."
+		# Ensure /usr/bin/siteworx is executable
+		elif ! [[ -x "$siteworx" ]]; then
+			control_panel="error"
+			eout "{panel} Interworx found, but Siteworx CLI is missing or not executable. Panel user alerts will not be sent."
+		else
+			control_panel="interworx"
+		fi
+	elif [[ -d /usr/local/cpanel ]]; then
+		cpanel_ps=$(ps -u root | grep [c]psrvd)
+		cpapi=$(which cpapi2)
+		apitool=$(readlink -e ${cpapi})
+
+		# Ensure cpanel service is running
+		if [[ -z ${cpanel_ps} ]]; then
+			control_panel="error"
+			eout "{panel} cPanel found, but services are not running. Panel user alerts will not be sent."
+		# Verify apitool is executable
+		elif ! [[ -x ${apitool} ]]; then
+			control_panel="error"
+			eout "{panel} cPanel found, but apitool is missing or not found. Panel user alerts will not be sent."
+		else
+			control_panel="cpanel"
+		fi
+	else
+		control_panel="unknown"
+	fi
+}
+
+get_panel_contacts() {
+	panel="$1"
+	user="$2"
+	contact_emails=""
+	case "$panel" in
+		"cpanel")
+			if [ -f /var/cpanel/users/${user} ]; then
+				contact_emails=$(awk -F '=' '/^CONTACTEMAIL/{print $2}'  /var/cpanel/users/${user} | sed '/^ *$/d' | tr '\n' ',' | sed 's/,$//')
+			else
+				contact_emails=$(cpapi2 --user=herpaderpadoo --output=xml CustInfo contactemails | grep -o 'value>.*</value' | sed -r 's,(</)?value>?,,g;/^$/d' | tr '\n' ',' | sed 's/,$//')
+			fi
+			break
+		;;
+		"interworx")
+			master_domain=$(/usr/local/interworx/bin/listaccounts.pex | grep "${user}" | awk "{print $2}")
+			contact_emails=$(/usr/bin/siteworx -un --login_domain ${master_domain} -c Users -a listUsers -o yaml | awk '/email:/{print $2}' | tr '\n' ',' | sed 's/,$//')
+			break
+		;;
+	esac
+    echo $contact_emails
+}
+
 get_remote_file() {
 	# $1 = URI, $2 = local service identifier, $3 boolean verbose
 	get_uri="$1"

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1523,6 +1523,68 @@ genalert() {
 					eout "{alert} sent scan report to $email_addr" 1
 				fi
 			fi
+        elif [ "$type" == "panel" ] && [ -f "$file" ]; then 
+            # Sort malware hits from $file and map the detected files to their system user owner
+            file_hits=$(awk '/FILE HIT LIST:/{flag=1;next}/^=======/{flag=0}flag{print $3}' $file)
+            for hit in $file_hits; do
+                hit_line=$(grep "$hit" $file)
+                if [ -f "$hit" ]; then 
+                    file_owner=$(stat -c "%U" $hit)
+                elif ! [ -f "$hit" ] && [ "$quarantine_hits" == "1" ] && [[ "$hit_line" == *"=>"* ]]; then 
+                    quarantined_file=$(echo $hit_line | awk '{print $NF}')
+                    file_owner=$(awk -F':' '/^[^#]/{print $1}' ${quarantined_file}.info)
+                fi   
+                echo "$file_owner : $hit" >> $tmpdir/.panel_alert.hits
+            done 
+            # Sort cleaned files too
+            if [ "$quarantine_clean" == "1" ]; then 
+                for clean_file in $(cat $sessdir/clean.$$); do
+                    if [ -f $clean_file ]; then 
+                        clean_owner=$(stat -c "%U" $clean_file)
+                    fi   
+                    echo "$clean_owner : $clean_file" >> $tmpdir/.panel_alert.clean
+                done 
+            fi   
+            # Determine control panel, noop if error or none detected
+            control_panel=""
+            detect_control_panel
+            if [ "$control_panel" == "error" ] || [ "$control_panel" == "unknown" ]; then 
+                eout "{panel} Failed to set control panel. Will not send alerts to control panel account contacts." 1
+            else 
+                eout "{panel} Detected control panel $control_panel. Will send alerts to control panel account contacts." 1
+                user_list=$(awk '{print $1}' $tmpdir/.panel_alert.hits)
+                for sys_user in $user_list; do
+                    contact_emails=$(get_panel_contacts $control_panel $sys_user)
+
+                    grep "^$sys_user " $tmpdir/.panel_alert.hits | awk '{print $3}' > $tmpdir/.${sys_user}.hits
+                    user_tot_hits=$($wc -l $tmpdir/.${sys_user}.hits | awk '{print$1}')
+                    if [ -f $tmpdir/.panel_alert.clean ]; then 
+                        grep "^$sys_user " $tmpdir/.panel_alert.clean | awk '{print $3}' > $tmpdir/.${sys_user}.clean
+                        user_tot_cl=$($wc -l $tmpdir/.${sys_user}.clean | awk '{print$1}')
+                    fi   
+
+                    tmpf=$tmpdir/.${sys_user}.alert
+                    echo "TO: $contact_emails" > $tmpf
+                    echo "FROM: $email_panel_from" >> $tmpf
+                    echo "REPLY-TO: $email_panel_replyto" >> $tmpf
+                    . $email_panel_alert_etpl
+
+                    if [ -f "$mail" ]; then 
+                        if ! grep -q "SUBJECT: " "$tmpf"; then 
+                            cat $tmpf | $mail -s "$email_subj" $email_addr
+                        else 
+                            cat $tmpf | $mail $email_addr
+                        fi   
+                    elif [ -f "$sendmail" ]; then 
+                        if ! grep -q "SUBJECT: " "$tmpf"; then 
+                            echo -e "SUBJECT: $email_subj\n$(cat $file)" > $tmpf
+                        fi   
+                        cat $tmpf | $sendmail -t $email_addr
+                    else 
+                        eout "{scan} no \$mail or \$sendmail binaries found, e-mail alerts disabled."
+                    fi   
+                done 
+            fi   
 		elif [ "$type" == "daily" ] || [ "$type" == "digest" ]; then
 			inotify_start_time=`ps -p $(ps -A -o 'pid cmd' | grep -E maldetect | grep -E inotifywait | awk '{print$1}' | head -n1) -o lstart= 2> /dev/null`
 			scan_start_hr=`date -d "$inotify_start_time" +"%b %e %Y %H:%M:%S %z"`

--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1521,64 +1521,66 @@ genalert() {
 				fi
 			fi
         elif [ "$type" == "panel" ] && [ -f "$file" ]; then 
-	    eout "{panel} Detecting control panel and sending alerts..." 1
-            # Sort malware hits from $file and map the detected files to their system user owner
-            file_hits=$(awk '/FILE HIT LIST:/{flag=1;next}/^=======/{flag=0}flag{print $3}' $file)
-            for hit in $file_hits; do
-                hit_line=$(grep "$hit" $file)
-                if [ -f "$hit" ]; then 
-                    file_owner=$(stat -c "%U" $hit)
-                elif ! [ -f "$hit" ] && [ "$quarantine_hits" == "1" ] && [[ "$hit_line" == *"=>"* ]]; then 
-                    quarantined_file=$(echo $hit_line | awk '{print $NF}')
-                    file_owner=$(awk -F':' '/^[^#]/{print $1}' ${quarantined_file}.info)
-                fi   
-                echo "$file_owner : $hit" >> $tmpdir/.panel_alert.hits
-            done 
-            # Sort cleaned files too
-            if [ "$quarantine_clean" == "1" ]; then 
-                for clean_file in $(cat $sessdir/clean.$$); do
-                    if [ -f $clean_file ]; then 
-                        clean_owner=$(stat -c "%U" $clean_file)
-                    fi   
-                    echo "$clean_owner : $clean_file" >> $tmpdir/.panel_alert.clean
-                done 
-            fi   
-            # Determine control panel, noop if error or none detected
+	    	eout "{panel} Detecting control panel and sending alerts..." 1
             control_panel=""
             detect_control_panel
             if [ "$control_panel" == "error" ] || [ "$control_panel" == "unknown" ]; then 
                 eout "{panel} Failed to set control panel. Will not send alerts to control panel account contacts." 1
             else 
+            	# Sort malware hits from $file and map the detected files to their system user owner
+            	file_hits=$(awk '/FILE HIT LIST:/{flag=1;next}/^=======/{flag=0}flag{print $3}' $file)
+            	for hit in $file_hits; do
+            	    hit_line=$(grep "$hit" $file)
+            	    if [ -f "$hit" ]; then 
+            	        file_owner=$(stat -c "%U" $hit)
+            	    elif ! [ -f "$hit" ] && [ "$quarantine_hits" == "1" ] && [[ "$hit_line" == *"=>"* ]]; then 
+            	        quarantined_file=$(echo $hit_line | awk '{print $NF}')
+            	        file_owner=$(awk -F':' '/^[^#]/{print $1}' ${quarantined_file}.info)
+            	    fi   
+            	    echo "$file_owner : $hit" >> $tmpdir/.panel_alert.hits
+            	done 
+            	# Sort cleaned files too
+            	if [ "$quarantine_clean" == "1" ]; then 
+            	    for clean_file in $(cat $sessdir/clean.$$); do
+            	        if [ -f $clean_file ]; then 
+            	            clean_owner=$(stat -c "%U" $clean_file)
+            	        fi   
+            	        echo "$clean_owner : $clean_file" >> $tmpdir/.panel_alert.clean
+            	    done 
+            	fi   
+            	# Determine control panel, noop if error or none detected
                 eout "{panel} Detected control panel $control_panel. Will send alerts to control panel account contacts." 1
                 user_list=$(awk '{print $1}' $tmpdir/.panel_alert.hits | sort | uniq)
-                for sys_user in $user_list; do
-		    contact_emails=""
-                    get_panel_contacts $control_panel $sys_user
+				if [ -n "$user_list"]; then
+                	for sys_user in $user_list; do
+                	    contact_emails=""
+                	    get_panel_contacts $control_panel $sys_user
 
-                    grep "^$sys_user " $tmpdir/.panel_alert.hits | awk '{print $3}' > $tmpdir/.${sys_user}.hits
-                    user_tot_hits=$($wc -l $tmpdir/.${sys_user}.hits | awk '{print$1}')
-                    if [ -f $tmpdir/.panel_alert.clean ]; then 
-                        grep "^$sys_user " $tmpdir/.panel_alert.clean | awk '{print $3}' > $tmpdir/.${sys_user}.clean
-                        user_tot_cl=$($wc -l $tmpdir/.${sys_user}.clean | awk '{print$1}')
-                    fi   
+                	    grep "^$sys_user " $tmpdir/.panel_alert.hits | awk '{print $3}' > $tmpdir/.${sys_user}.hits
+                	    user_tot_hits=$($wc -l $tmpdir/.${sys_user}.hits | awk '{print$1}')
+                	    if [ -f $tmpdir/.panel_alert.clean ]; then 
+                	        grep "^$sys_user " $tmpdir/.panel_alert.clean | awk '{print $3}' > $tmpdir/.${sys_user}.clean
+                	        user_tot_cl=$($wc -l $tmpdir/.${sys_user}.clean | awk '{print$1}')
+                	    fi   
 
-                    tmpf=$tmpdir/.${sys_user}.alert
+                	    tmpf=$tmpdir/.${sys_user}.alert
 
-                    if [ -f "$sendmail" ]; then 
-			echo "TO: $contact_emails" > $tmpf
-                        echo "FROM: $email_panel_from" >> $tmpf
-                        echo "REPLY-TO: $email_panel_replyto" >> $tmpf
-		        echo -e "SUBJECT: $email_panel_alert_subj\n" >> $tmpf
-                        . $email_panel_alert_etpl
+                	    if [ -f "$sendmail" ]; then 
+							echo "TO: $contact_emails" > $tmpf
+                	        echo "FROM: $email_panel_from" >> $tmpf
+                	        echo "REPLY-TO: $email_panel_replyto" >> $tmpf
+							echo -e "SUBJECT: $email_panel_alert_subj\n" >> $tmpf
+                	        . $email_panel_alert_etpl
 
-                        cat $tmpf | $sendmail -t
-                    elif [ -f "$mail" ] && [ "$control_panel" == "cpanel" ]; then 
-                        . $email_panel_alert_etpl
-                    	cat $tmpf | $mail -r $email_panel_from -s $email_panel_alert_subj $contact_emails
-                    else 
-                        eout "{panel} No compatible \$sendmail or \$mail binaries found, control panel account alerts disabled."
-                    fi   
-                done 
+                	        cat $tmpf | $sendmail -t
+                	    elif [ -f "$mail" ] && [ "$control_panel" == "cpanel" ]; then 
+                	        . $email_panel_alert_etpl
+                	    	cat $tmpf | $mail -r $email_panel_from -s $email_panel_alert_subj $contact_emails
+                	    else 
+                	        eout "{panel} No compatible \$sendmail or \$mail binaries found, control panel account alerts disabled."
+                	    fi   
+                	done 
+				fi
             fi   
 		elif [ "$type" == "daily" ] || [ "$type" == "digest" ]; then
 			inotify_start_time=`ps -p $(ps -A -o 'pid cmd' | grep -E maldetect | grep -E inotifywait | awk '{print$1}' | head -n1) -o lstart= 2> /dev/null`

--- a/files/internals/importconf
+++ b/files/internals/importconf
@@ -33,17 +33,20 @@ email_ignore_clean="1"
 # toolset and send an email summary of the detected hits to that user.
 # The list of hits will be limited to files owned by the panel user/account in question.
 # Disabling alerts globally with email_alert will also disable this function.
-email_panel_user_alerts="0"
+email_panel_user_alerts="$email_panel_user_alerts"
 
 # The from header that will be set on alerts to control panel users. This should
 # be set by any web hosts that will be supporting the control panel users/accounts 
 # on this server.
-email_panel_from="you@example.com"
+email_panel_from="$email_panel_from"
 
 # The reply-to header that will be set on alerts to control panel users. This should
 # be set by any web hosts that will be supporting the control panel users/accounts 
 # on this server.
-email_panel_replyto="you@example.com"
+email_panel_replyto="$email_panel_replyto"
+
+# The subject that will be used on alerts to control panel account contacts
+email_panel_alert_subj="$email_panel_alert_subj"
 
 # This controls the daily automatic updates of LMD signature files
 # and cleaner rules. The signature update process preserves any

--- a/files/internals/importconf
+++ b/files/internals/importconf
@@ -27,6 +27,24 @@ email_addr="$email_addr"
 # [0 = disabled, 1 = enabled]
 email_ignore_clean="1"
 
+# Enable user alerts for specific web hosting control panels. If hits are detected,
+# attempt to determine the web hosting control in use, if any. If a control
+# panel is detected, determine the user contact information from the panel's
+# toolset and send an email summary of the detected hits to that user.
+# The list of hits will be limited to files owned by the panel user/account in question.
+# Disabling alerts globally with email_alert will also disable this function.
+email_panel_user_alerts="0"
+
+# The from header that will be set on alerts to control panel users. This should
+# be set by any web hosts that will be supporting the control panel users/accounts 
+# on this server.
+email_panel_from="you@example.com"
+
+# The reply-to header that will be set on alerts to control panel users. This should
+# be set by any web hosts that will be supporting the control panel users/accounts 
+# on this server.
+email_panel_replyto="you@example.com"
+
 # This controls the daily automatic updates of LMD signature files
 # and cleaner rules. The signature update process preserves any
 # custom signature or cleaner files. It is highly recommended that this

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -124,6 +124,7 @@ hex_string_script="$libpath/hexstring.pl"
 scan_user_access_minuid=100
 find_opts="-regextype posix-egrep"
 email_template="$libpath/scan.etpl"
+email_panel_alert_etpl="$libpath/panel_alert.etpl"
 email_subj="maldet alert from $(hostname)"
 cron_custom_exec="$confpath/cron/custom.cron"
 cron_custom_conf="$confpath/cron/conf.maldet.cron"

--- a/files/internals/panel_alert.etpl
+++ b/files/internals/panel_alert.etpl
@@ -1,0 +1,72 @@
+if [ -z "$type" ]; then
+	type=scan
+fi
+cat >> $tmpf <<EOF
+HOST:      $HOSTNAME
+SCAN ID:   $scanid
+STARTED:   $scan_start_hr
+COMPLETED: $scan_end_hr
+ELAPSED:   ${scan_et}s [find: ${file_list_et}s]
+
+EOF
+if [ "$spath" ]; then
+	echo "PATH:          $hrspath" >> $tmpf
+fi
+if [ "$days" ] && [ ! "$days" == "all" ]; then
+	echo "RANGE:         $days days" >> $tmpf
+fi
+cat >> $tmpf <<EOF
+TOTAL HITS:    $user_tot_hits
+TOTAL CLEANED: $user_tot_cl
+
+EOF
+if [ "$quarantine_hits" == "0" ] && [ ! "$tot_hits" == "0" ]; then
+ echo "WARNING: Automatic quarantine is currently disabled, detected threats are still accessible to users!" >> $tmpf
+ echo "To enable, set quarantine_hits=1 and/or to quarantine hits from this scan run:" >> $tmpf
+ echo -e "/usr/local/sbin/maldet -q $datestamp.$$\n" >> $tmpf
+elif [ "$quarantine_hits" == "1" ]; then
+ echo "NOTICE: Automatic quarantine is enabled, and all detected threats have been quarantined." >> $tmpf
+ echo "All quarantined files have been moved to $quardir, and their metadata have been preserved." >> $tmpf
+ echo "Please see below for details on which files have been moved to quarantine." >> $tmpf
+fi
+if [ "$quarantine_clean" == "1" ]; then
+  if [ "$type" == "scan" ] && [ -f "$sessdir/clean.$$" ] && [ ! -z "$(cat $sessdir/clean.$$)" ]; then
+	cleaned_list="$sessdir/clean.$$"
+  fi
+  if [ -f "$cleaned_list" ]; then
+cat >> $tmpf <<EOF
+CLEANED & RESTORED FILES:
+$(cat $cleaned_list)
+
+EOF
+  fi
+ if [ "$quarantine_suspend_user" == "1" ]; then
+  if [ -f "$sessdir/suspend.users.$$" ] && [ ! -z "$(cat $sessdir/suspend.users.$$)" ]; then
+	suspended_list="$sessdir/suspend.users.$$"
+  fi
+  if [ -f "$suspended_list" ]; then
+cat >> $tmpf <<EOF
+SUSPENDED ACCOUNTS:
+$(cat "$suspended_list")
+
+EOF
+  fi
+ fi
+fi
+
+if [ ! "$user_tot_hits" == "0" ]; then
+ hitlist_file="$tmpdir/.${sys_user}.hits"
+ if [ -f "$hitlist_file" ]; then
+ 	echo "FILE HIT LIST:" >> $tmpf
+        if [ "$coltest" ]; then
+                cat $hitlist_file | column -s ':' -t -o ':' >> $tmpf
+        else
+                cat $hitlist_file >> $tmpf
+        fi
+ fi
+fi
+
+cat >> $tmpf <<EOF
+===============================================
+Linux Malware Detect v$ver < proj@rfxn.com >
+EOF


### PR DESCRIPTION
## **Description**
Adds functionality to enable alerts to control panel user contact emails. Includes the following functions:

- Auto detects control panel, if one is installed (currently supports cPanel and Interworx)
- Obtains contact emails through panel-native tools for a given account
- Sends alerts with a file hit list to discovered contact emails

## **Changes**
- Add detect_control_panel function to files/internals/functions to determine installed control panel.
- Add get_panel_contacts to files/internals/functions to discover contact emails
- Add configuration options for From, Subject, Reply-To headers on alert emails
- Add flag to enable these alerts (requires email_alert to be enabled as well)
- Add internal configuration to set the user alert template location
- Add a base template that will be used to create emails to control panel contacts

## **Testing**

### **<edit here>**
<details>
<summary>CentOS 6, no control panel</summary>

```
[root@lmd-cent6 linux-malware-detect]# maldet -a /home/
Linux Malware Detect v1.6.5
            (C) 2002-2019, R-fx Networks <proj@rfxn.com>
            (C) 2019, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(8544): {scan} signatures loaded: 17370 (14533 MD5 | 2054 HEX | 783 YARA | 0 USER)
maldet(8544): {scan} building file list for /home/, this might take awhile...
maldet(8544): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(8544): {scan} file list completed in 0s, found 1918 files...
maldet(8544): {scan} scan of /home/ (1918 files) in progress...
maldet(8544): {scan} 1918/1918 files scanned: 554 hits 0 cleaned

maldet(8544): {scan} scan completed on /home/: files 1918, malware hits 554, cleaned hits 0, time 138s
maldet(8544): {scan} scan report saved, to view run: maldet --report 230314-2156.8544
maldet(8544): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 230314-2156.8544
maldet(8544): {alert} sent scan report to cclare@nexcess.net

[root@lmd-cent6 linux-malware-detect]# grep ^email_ /usr/local/maldetect/conf.maldet
email_alert="1"
email_addr="cclare@nexcess.net"
email_ignore_clean="1"
email_panel_user_alerts="0"
email_panel_from="you@example.com"
email_panel_replyto="you@example.com"
```

</details>

<details>
<summary>CentOS 7, no control panel</summary>

```
[root@lmd-centos linux-malware-detect]# maldet -a /home/ 
Linux Malware Detect v1.6.5
            (C) 2002-2019, R-fx Networks <proj@rfxn.com>
            (C) 2019, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(22534): {scan} signatures loaded: 17370 (14533 MD5 | 2054 HEX | 783 YARA | 0 USER)
maldet(22534): {scan} building file list for /home/, this might take awhile...
maldet(22534): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(22534): {scan} file list completed in 0s, found 1934 files...
maldet(22534): {scan} scan of /home/ (1934 files) in progress...
maldet(22534): {scan} 1934/1934 files scanned: 554 hits 0 cleaned

maldet(22534): {scan} scan completed on /home/: files 1934, malware hits 554, cleaned hits 0, time 121s
maldet(22534): {scan} scan report saved, to view run: maldet --report 230314-2031.22534
maldet(22534): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 230314-2031.22534
maldet(22534): {alert} sent scan report to cclare@nexcess.net

[root@lmd-centos linux-malware-detect]# grep ^email_ /usr/local/maldetect/conf.maldet
email_alert="1"
email_addr="cclare@nexcess.net"
email_ignore_clean="1"
email_panel_user_alerts="0"
email_panel_from="you@example.com"
email_panel_replyto="you@example.com"
```

</details>

<details>
<summary>Ubuntu 20.04, no control panel</summary>

```
root@lmd-ubuntu:~/linux-malware-detect# maldet -a /home/
Linux Malware Detect v1.6.5
            (C) 2002-2019, R-fx Networks <proj@rfxn.com>
            (C) 2019, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(100738): {scan} signatures loaded: 17370 (14533 MD5 | 2054 HEX | 783 YARA | 0 USER)
maldet(100738): {scan} building file list for /home/, this might take awhile...
maldet(100738): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(100738): {scan} file list completed in 0s, found 1924 files...
maldet(100738): {scan} scan of /home/ (1924 files) in progress...
maldet(100738): {scan} 1924/1924 files scanned: 554 hits 0 cleaned

maldet(100738): {scan} scan completed on /home/: files 1924, malware hits 554, cleaned hits 0, time 182s
maldet(100738): {scan} scan report saved, to view run: maldet --report 230314-2054.100738
maldet(100738): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 230314-2054.100738
maldet(100738): {alert} sent scan report to cclare@nexcess.net

root@lmd-ubuntu:~/linux-malware-detect# grep ^email_ /usr/local/maldetect/conf.maldet
email_alert="1"
email_addr="cclare@nexcess.net"
email_ignore_clean="1"
email_panel_user_alerts="0"
email_panel_from="you@example.com"
email_panel_replyto="you@example.com"

## One additional test to verify that enabling control panel alerts logs an error or otherwise does not send an alert
root@lmd-ubuntu:~/linux-malware-detect# maldet -a /home/
Linux Malware Detect v1.6.5
            (C) 2002-2019, R-fx Networks <proj@rfxn.com>
            (C) 2019, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(273513): {scan} signatures loaded: 17370 (14533 MD5 | 2054 HEX | 783 YARA | 0 USER)
maldet(273513): {scan} building file list for /home/, this might take awhile...
maldet(273513): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(273513): {scan} file list completed in 1s, found 1924 files...
maldet(273513): {scan} scan of /home/ (1924 files) in progress...
maldet(273513): {scan} 1924/1924 files scanned: 554 hits 0 cleaned

maldet(273513): {scan} scan completed on /home/: files 1924, malware hits 554, cleaned hits 0, time 179s
maldet(273513): {scan} scan report saved, to view run: maldet --report 230317-2008.273513
maldet(273513): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 230317-2008.273513
maldet(273513): {alert} sent scan report to cclare@nexcess.net
maldet(273513): {panel} Detecting control panel and sending alerts...
maldet(273513): {panel} Failed to set control panel. Will not send alerts to control panel account contacts.
```

</details>

<details>
<summary>CentOS 7, cPanel 108</summary>
[root@cpanel linux-malware-detect]# maldet -a /home/
Linux Malware Detect v1.6.5
            (C) 2002-2019, R-fx Networks <proj@rfxn.com>
            (C) 2019, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(67993): {scan} signatures loaded: 17370 (14533 MD5 | 2054 HEX | 783 YARA | 0 USER)
maldet(67993): {scan} building file list for /home/, this might take awhile...
maldet(67993): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(67993): {scan} file list completed in 0s, found 1801 files...
maldet(67993): {scan} found clamav binary at /usr/local/cpanel/3rdparty/bin/clamscan, using clamav scanner engine...
maldet(67993): {scan} scan of /home/ (1801 files) in progress...
maldet(67993): {scan} processing scan results for hits: 936 hits 0 cleaned
maldet(67993): {scan} scan completed on /home/: files 1801, malware hits 936, cleaned hits 0, time 112s
maldet(67993): {scan} scan report saved, to view run: maldet --report 230317-1119.67993
maldet(67993): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 230317-1119.67993
maldet(67993): {alert} sent scan report to cclare@nexcess.net
maldet(67993): {alert} Panel alerts
maldet(67993): {panel} Detecting control panel and sending alerts...
maldet(67993): {panel} Detected control panel cpanel. Will send alerts to control panel account contacts.
</details>

<details>
<summary>CentOS 7, Interworx </summary>
[root@lmd-iworx7 linux-malware-detect]# maldet -a /home/
Linux Malware Detect v1.6.5
            (C) 2002-2019, R-fx Networks <proj@rfxn.com>
            (C) 2019, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(21699): {scan} signatures loaded: 17370 (14533 MD5 | 2054 HEX | 783 YARA | 0 USER)
maldet(21699): {scan} building file list for /home/, this might take awhile...
maldet(21699): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(21699): {scan} file list completed in 0s, found 2003 files...
maldet(21699): {scan} found clamav binary at /usr/bin/clamdscan, using clamav scanner engine...
maldet(21699): {scan} scan of /home/ (2003 files) in progress...
maldet(21699): {scan} processing scan results for hits: 1037 hits 0 cleaned
maldet(21699): {scan} scan completed on /home/: files 2003, malware hits 1037, cleaned hits 0, time 119s
maldet(21699): {scan} scan report saved, to view run: maldet --report 230317-1519.21699
maldet(21699): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 230317-1519.21699
maldet(21699): {alert} sent scan report to cclare@nexcess.net
maldet(21699): {alert} Panel alerts
maldet(21699): {panel} Detecting control panel and sending alerts...
maldet(21699): {panel} Detected control panel interworx. Will send alerts to control panel account contacts.

## Test to verify that disabling email_alert disables control panel user alerts as well
[root@lmd-iworx7 linux-malware-detect]# grep ^email_alert /usr/local/maldetect/conf.maldet
email_alert="0"
[root@lmd-iworx7 linux-malware-detect]# maldet -a /home/
Linux Malware Detect v1.6.5
            (C) 2002-2019, R-fx Networks <proj@rfxn.com>
            (C) 2019, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(27655): {scan} signatures loaded: 17370 (14533 MD5 | 2054 HEX | 783 YARA | 0 USER)
maldet(27655): {scan} building file list for /home/, this might take awhile...
maldet(27655): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(27655): {scan} file list completed in 0s, found 2003 files...
maldet(27655): {scan} found clamav binary at /usr/bin/clamdscan, using clamav scanner engine...
maldet(27655): {scan} scan of /home/ (2003 files) in progress...
maldet(27655): {scan} processing scan results for hits: 1037 hits 0 cleaned
maldet(27655): {scan} scan completed on /home/: files 2003, malware hits 1037, cleaned hits 0, time 115s
maldet(27655): {scan} scan report saved, to view run: maldet --report 230317-2014.27655
maldet(27655): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 230317-2014.27655
</details>

## Misc
Malware samples for testing obtained from the following repos:
https://github.com/JohnTroony/php-webshells
https://github.com/tennc/webshell