### PR TITLE
fix setting scan_max_filesize

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -893,15 +893,19 @@ quar_hitlist() {
 }
 
 clamselector() {
-        scan_max_filesize=`cat $sig_md5_file | cut -d':' -f2 | sort -n | tail -n1`
-        if [ "$scan_max_filesize" -gt "1" 2> /dev/null ]; then
-                scan_max_filesize=$[scan_max_filesize+1]
-                clamscan_max_filesize="${scan_max_filesize}"
-                scan_max_filesize="${scan_max_filesize}c"
+        sig_max_filesize=`cat $sig_md5_file | cut -d':' -f2 | sort -n | tail -n1`
+        if [ "$sig_max_filesize" -gt "1" 2> /dev/null ]; then
+                if [ -z "$scan_max_filesize" ]; then
+                        scan_max_filesize="${scan_max_filesize}c"
+                fi
+                clamscan_max_filesize=$[sig_max_filesize+1]
         else
-                scan_max_filesize="2048k"
+                if [ -z "$scan_max_filesize" ]; then
+                        scan_max_filesize="2048k"
+                fi
                 clamscan_max_filesize="2592000"
         fi
+
 
         if [ "$scan_clamscan" == "1" ]; then
                 trim_log $clamscan_log 10000 1


### PR DESCRIPTION
the variable name $scan_max_filesize is being used to store the configuration value for the largest file size that should be scanned which is passed to find and also the largest file size in the signatures.

add a new variable called $sig_max_filesize for that purpose and add a conditional check so that we don't override $scan_max_filesize if the user has set it in the configuration

this definitely needs some scrutiny