### PR TITLE
Add signature to panel alerts and fix some white spacing issues

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -284,7 +284,9 @@ get_panel_contacts() {
 		;;
 		"interworx")
 			master_domain=$(/usr/local/interworx/bin/listaccounts.pex | grep "${user}" | awk '{print $2}')
-			contact_emails=$(/usr/bin/siteworx -un --login_domain ${master_domain} -c Users -a listUsers -o yaml | awk '/email:/{print $2}' | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /')
+			if [[ -n $master_domain ]]; then
+				contact_emails=$(/usr/bin/siteworx -un --login_domain "${master_domain}" -c Users -a listUsers -o yaml | awk '/email:/{print $2}' | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /')
+			fi
 		;;
 	esac
 }
@@ -443,7 +445,7 @@ EOF
 }
 
 usage_long() {
-cat<<EOF
+cat <<EOF
 signature set: $sig_version
 usage $0 [ OPTION ]
     -b, --background
@@ -1497,7 +1499,7 @@ trim_log() {
 genalert() {
 	type="$1"
 	file="$2"
-        if [ "$email_alert" == "1" ] || [ "$type" == "digest" ] || [ "$type" == "daily" ]; then
+	if [ "$email_alert" == "1" ] || [ "$type" == "digest" ] || [ "$type" == "daily" ]; then
 		if [ "$type" == "file" ] && [ -f "$file" ]; then
 			if [ -f "$mail" ]; then
                 cat $file | $mail -s "$email_subj" $email_addr
@@ -1522,24 +1524,30 @@ genalert() {
 				fi
 			fi
         elif [ "$type" == "panel" ] && [ -f "$file" ]; then 
-	    eout "{panel} Detecting control panel and sending alerts..." 1
+			eout "{panel} Detecting control panel and sending alerts..." 1
             control_panel=""
             detect_control_panel
             if [ "$control_panel" == "error" ] || [ "$control_panel" == "unknown" ]; then 
                 eout "{panel} Failed to set control panel. Will not send alerts to control panel account contacts." 1
             else 
             	# Sort malware hits from $file and map the detected files to their system user owner
-            	file_hits=$(awk '/FILE HIT LIST:/{flag=1;next}/^=======/{flag=0}flag{print $3}' $file)
-            	for hit in $file_hits; do
-            	    hit_line=$(grep "$hit" $file)
-            	    if [ -f "$hit" ]; then 
-            	        file_owner=$(stat -c "%U" $hit)
-            	    elif ! [ -f "$hit" ] && [ "$quarantine_hits" == "1" ] && [[ "$hit_line" == *"=>"* ]]; then 
-            	        quarantined_file=$(echo $hit_line | awk '{print $NF}')
+            	while read -r hit; do
+					local signature hit_file quarantined_file
+					if [[ $hit =~ (.*)[[:blank:]]:[[:blank:]](.*)[[:blank:]]=\>[[:blank:]](.*) ]]; then
+						signature=${BASH_REMATCH[1]}
+						hit_file=${BASH_REMATCH[2]}
+						quarantined_file=${BASH_REMATCH[3]}
+					elif [[ $hit =~ (.*)[[:blank:]]:[[:blank:]](.*) ]]; then
+						signature=${BASH_REMATCH[1]}
+						hit_file=${BASH_REMATCH[2]}
+					fi
+            	    if [[ -f $hit_file ]]; then
+            	        file_owner=$(stat -c "%U" "$hit_file")
+            	    elif [[ -n $quarantined_file ]]; then
             	        file_owner=$(awk -F':' '/^[^#]/{print $1}' ${quarantined_file}.info)
-            	    fi   
-            	    echo "$file_owner : $hit" >> $tmpdir/.panel_alert.hits
-            	done 
+            	    fi
+            	    echo "$file_owner : $signature : $hit_file" >> $tmpdir/.panel_alert.hits
+            	done < <(awk '/FILE HIT LIST:/{flag=1;next}/^=======/{flag=0}flag{print $0}' $file)
             	# Sort cleaned files too
             	if [ "$quarantine_clean" == "1" ]; then 
             	    for clean_file in $(cat $sessdir/clean.$$); do
@@ -1552,12 +1560,12 @@ genalert() {
             	# Determine control panel, noop if error or none detected
                 eout "{panel} Detected control panel $control_panel. Will send alerts to control panel account contacts." 1
                 user_list=$(awk '{print $1}' $tmpdir/.panel_alert.hits | sort | uniq)
-		if [ -n "$user_list" ]; then
+				if [ -n "$user_list" ]; then
                 	for sys_user in $user_list; do
                 	    contact_emails=""
                 	    get_panel_contacts $control_panel $sys_user
 
-                	    grep "^$sys_user " $tmpdir/.panel_alert.hits | awk '{print $3}' > $tmpdir/.${sys_user}.hits
+						grep "^$sys_user " $tmpdir/.panel_alert.hits | awk -F' : ' '{print $2" : "$3}' > $tmpdir/.${sys_user}.hits
                 	    user_tot_hits=$($wc -l $tmpdir/.${sys_user}.hits | awk '{print$1}')
                 	    if [ -f $tmpdir/.panel_alert.clean ]; then 
                 	        grep "^$sys_user " $tmpdir/.panel_alert.clean | awk '{print $3}' > $tmpdir/.${sys_user}.clean
@@ -1581,8 +1589,8 @@ genalert() {
                 	        eout "{panel} No compatible \$sendmail or \$mail binaries found, control panel account alerts disabled."
                 	    fi   
                 	done 
-		fi
-		rm -f $tmpdir/.panel_alert.hits $tmpdir/.panel_alert.clean $tmpdir/.${sys_user}.hits $tmpdir/.${sys_user}.clean $tmpf
+				fi
+				rm -f $tmpdir/.panel_alert.hits $tmpdir/.panel_alert.clean $tmpdir/.${sys_user}.hits $tmpdir/.${sys_user}.clean $tmpf
             fi   
 		elif [ "$type" == "daily" ] || [ "$type" == "digest" ]; then
 			inotify_start_time=`ps -p $(ps -A -o 'pid cmd' | grep -E maldetect | grep -E inotifywait | awk '{print$1}' | head -n1) -o lstart= 2> /dev/null`


### PR DESCRIPTION
Tests:
```
$ maldet -a /home/aeb2c860/390592c2cd.nxcli.io/test/
Linux Malware Detect v1.6.5
            (C) 2002-2023, R-fx Networks <proj@rfxn.com>
            (C) 2023, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(10012): {scan} signatures loaded: 17637 (14801 MD5 | 2053 HEX | 783 YARA | 0 USER)
maldet(10012): {scan} building file list for /home/aeb2c860/test/, this might take awhile...
maldet(10012): {scan} setting maximum execution time for 'find' file list: 28800sec
maldet(10012): {scan} setting nice scheduler priorities for all operations: cpunice 18 , ionice 6
maldet(10012): {scan} file list completed in 0s, found 732 files...
maldet(10012): {scan} found clamav binary at /bin/clamdscan, using clamav scanner engine...
maldet(10012): {scan} scan of /home/aeb2c860/test/ (732 files) in progress...
maldet(10012): {scan} processing scan results for hits: 1 hits 0 cleaned
maldet(10012): {scan} scan completed on /home/aeb2c860/test/: files 732, malware hits 1, cleaned hits 0, time 1s
maldet(10012): {scan} scan report saved, to view run: maldet --report 231106-2138.10012
maldet(10012): {scan} quarantine is disabled! set quarantine_hits=1 in conf.maldet or to quarantine results run: maldet -q 231106-2138.10012
maldet(10012): {alert} sent scan report to EMAILADDR
maldet(10012): {panel} Detecting control panel and sending alerts...
maldet(10012): {panel} Detected control panel interworx. Will send alerts to control panel account contacts.
```

Email received:
```
FILE HIT LIST:
{YARA}nex_webshell_options : /chroot/home/aeb2c860/test/infected.php
```

Test with quarantine:
```
$ maldet -a /home/aeb2c860/390592c2cd.nxcli.io/test/
Linux Malware Detect v1.6.5
            (C) 2002-2023, R-fx Networks <proj@rfxn.com>
            (C) 2023, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(15843): {scan} signatures loaded: 17637 (14801 MD5 | 2053 HEX | 783 YARA | 0 USER)
maldet(15843): {scan} building file list for /home/aeb2c860/test/, this might take awhile...
maldet(15843): {scan} setting maximum execution time for 'find' file list: 28800sec
maldet(15843): {scan} setting nice scheduler priorities for all operations: cpunice 18 , ionice 6
maldet(15843): {scan} file list completed in 0s, found 732 files...
maldet(15843): {scan} found clamav binary at /bin/clamdscan, using clamav scanner engine...
maldet(15843): {scan} scan of /home/aeb2c860/test/ (732 files) in progress...
maldet(15843): {scan} processing scan results for hits: 1 hits 0 cleaned
maldet(15843): {scan} scan completed on /home/aeb2c860/test/: files 732, malware hits 1, cleaned hits 0, time 2s
maldet(15843): {scan} scan report saved, to view run: maldet --report 231106-2142.15843
maldet(15843): {alert} sent scan report to EMAIL
maldet(15843): {panel} Detecting control panel and sending alerts...
maldet(15843): {panel} Detected control panel interworx. Will send alerts to control panel account contacts.
```

Email list:
```
FILE HIT LIST:
{YARA}nex_webshell_options : /chroot/home/aeb2c860/test/infected.php
```