### PR TITLE
cron.daily: Use `find -delete` instead of `xargs rm -f`

### DIFF
--- a/cron.daily
+++ b/cron.daily
@@ -43,7 +43,7 @@ if [ "$find" ]; then
 	tmpdirs="$tmpdir $varlibpath/sess $varlibpath/quarantine $varlibpath/pub"
 	for dir in $tmpdirs; do
 	 if [ -d "$dir" ]; then
-	  $find $dir -type f -mtime +${cron_prune_days} -print0 | xargs -0 rm -f >> /dev/null 2>&1
+	  $find $dir -type f -mtime +${cron_prune_days} -delete > /dev/null 2>&1
 	 fi
 	done
 fi


### PR DESCRIPTION
The removal of $runtime_ndb and $runtime_hdb in maldet causes a race condition with the daily cron on these files.
This correctly hides the cron's output when this race condition occurs.