### PR TITLE
Change the find_recentopts to not escape earlier validated statement …

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1168,7 +1168,7 @@ scan() {
 			if [ -z "$hscan" ]; then
 				eout "{scan} building file list for $hrspath of new/modified files from last $days days, this might take awhile..." 1
 			fi
-			find_recentopts="\( -mtime -$days -o -ctime -$days \)"
+			find_recentopts=" -mtime -$days -o -ctime -$days "
 		fi
 		
 		if [ -z "$scan_find_timeout" ];then


### PR DESCRIPTION
…issue #440 