### PR TITLE
Fix Telegram API not working

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1675,7 +1675,7 @@ genalert() {
 
 	if [ "$telegram_alert" == "1" ]; then
 		if [ "$type" == "file" ] && [ -f "$file" ]; then
-			telegram_response=$(curl -F "document=@$file" -F "caption=$telegram_file_caption" "https://api.telegram.org/$telegram_bot_token/sendDocument?chat_id=$telegram_channel_id" | grep -oP '^{"ok":true')
+			telegram_response=$(curl -F "document=@$file" -F "caption=$telegram_file_caption" "https://api.telegram.org/bot$telegram_bot_token/sendDocument?chat_id=$telegram_channel_id" | grep -oP '^{"ok":true')
 			if [ "$telegram_response" ]; then
 				eout "{alert} scan report sent to telegram channel: $telegram_channel_id" 0
 			else


### PR DESCRIPTION
The API URL as it is now is invalid, so it will fail regardless of whether both the token and channel ID are correct.

Here's it working with my change:
<img width="432" height="177" alt="Screenshot_20251217_165914" src="https://github.com/user-attachments/assets/e00ca5f3-ddef-4741-8c96-cd8931a65e85" />